### PR TITLE
Support Oh My Pi compatible hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pi-cliproxyapi-provider
 
-Pi provider extension that discovers models from [CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI) and registers them for use in pi. It supports catalog-driven OpenAI Fast mode and also ships a small TUI helper that shows elapsed runtime and a TPS summary after each agent turn.
+Provider extension that discovers models from [CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI) and registers them for use in Pi Coding Agent or compatible hosts such as Oh My Pi (OMP). It supports catalog-driven OpenAI Fast mode and also ships a small TUI helper that shows elapsed runtime and a TPS summary after each agent turn.
 
 ## What it does
 
@@ -16,19 +16,25 @@ Pi provider extension that discovers models from [CLIProxyAPI](https://github.co
 ## Install
 
 ```bash
-# from npm
+# Pi Coding Agent
 pi install npm:@router-for-me/pi-cliproxyapi-provider
+
+# Oh My Pi
+omp plugin install @router-for-me/pi-cliproxyapi-provider
 
 # from a local checkout
 pi install /absolute/path/to/pi-cliproxyapi-provider
+omp plugin link /absolute/path/to/pi-cliproxyapi-provider
 
-# or temporarily for one run
+# or temporarily for one Pi run
 pi -e /absolute/path/to/pi-cliproxyapi-provider
 ```
 
+Below, `<agent-dir>` means `~/.pi/agent` for Pi or `~/.omp/agent` for OMP.
+
 ## Login-style setup (recommended)
 
-This plugin needs both **baseUrl** and **apiKey**. pi's built-in `/login` only supports multi-field prompts on the account/OAuth path, so CLIProxyAPI appears under **Sign in with an account** (not API key).
+This plugin needs both **baseUrl** and **apiKey**. The host's built-in `/login` uses the account/OAuth path for multi-field prompts, so CLIProxyAPI appears under **Sign in with an account** (not API key).
 
 ### Preferred: /login shortcuts
 
@@ -42,7 +48,7 @@ or:
 /login cliproxyapi
 ```
 
-These shortcuts jump straight into CLIProxyAPI's multi-field baseUrl + API key prompts. The provider is registered as OAuth-only, so pi does not ask you to choose between API key and account first.
+These shortcuts jump straight into CLIProxyAPI's multi-field baseUrl + API key prompts. The provider is registered as OAuth-only, so the host does not ask you to choose between API key and account first.
 
 ### Menu path
 
@@ -67,8 +73,8 @@ Final login validation calls `{root}/v1/models?client_version=pi` (this always b
 On success:
 
 - models are registered immediately in the current session (0 models is allowed)
-- `baseUrl` / `apiKey` are written to `~/.pi/agent/cliproxyapi.json`
-- pi also stores the returned credential in `~/.pi/agent/auth.json`
+- `baseUrl` / `apiKey` are written to `<agent-dir>/cliproxyapi.json`
+- the host also stores the returned credential in `<agent-dir>/auth.json`
 
 Re-run `/login CLIProxyAPI` or `/login cliproxyapi` anytime to reconfigure. The built-in `/logout` command only removes credentials saved in `auth.json`; it does not erase `cliproxyapi.json`. Remove or update that file if you also need to clear the provider configuration.
 
@@ -78,7 +84,7 @@ You can still configure without `/login`.
 
 ### Config file
 
-`~/.pi/agent/cliproxyapi.json`:
+`<agent-dir>/cliproxyapi.json`:
 
 ```json
 {
@@ -130,7 +136,7 @@ Preferred form is **host:port only**:
 | `http://127.0.0.1:8317/v1` | `http://127.0.0.1:8317/backend-api/` | same models URL |
 | `127.0.0.1:8317` | `http://127.0.0.1:8317/backend-api/` | same models URL |
 
-pi then sends inference traffic to `{inference}/codex/responses`.
+The host then sends inference traffic to `{inference}/codex/responses`.
 
 ## Fast mode
 
@@ -142,11 +148,11 @@ Fast is **off by default**. Toggle the global preference with:
 /fast
 ```
 
-Each invocation switches Fast between on and off and writes the result to `~/.pi/agent/cliproxyapi.json`. On the next startup, a persisted `true` value immediately enables Fast for catalog-supported models. Fast remains ineffective for unsupported models, so their requests are left unchanged. If `CLIPROXYAPI_FAST` is set, that environment variable still takes precedence on startup.
+Each invocation switches Fast between on and off and writes the result to `<agent-dir>/cliproxyapi.json`. On the next startup, a persisted `true` value immediately enables Fast for catalog-supported models. Fast remains ineffective for unsupported models, so their requests are left unchanged. If `CLIPROXYAPI_FAST` is set, that environment variable still takes precedence on startup.
 
-When Fast is effective, pi's model status appends a yellow lowercase `fast`, for example `gpt-5.6-sol • xhigh • fast`. When Fast is off or the selected model is unsupported, the original model status remains unchanged. Supported models do not produce a separate status notification. Running `/fast` with an unsupported model still updates the global preference; enabling it warns that the current model cannot use Fast.
+When Fast is effective, the host's model status appends a yellow lowercase `fast`, for example `gpt-5.6-sol • xhigh • fast`. When Fast is off or the selected model is unsupported, the original model status remains unchanged. Supported models do not produce a separate status notification. Running `/fast` with an unsupported model still updates the global preference; enabling it warns that the current model cannot use Fast.
 
-Fast capability is catalog-driven: the plugin considers a CLIProxyAPI model Fast-capable when its `service_tiers` field is a non-empty array. The `additional_speed_tiers` field is ignored. For supported models, Fast injects `service_tier: "priority"`; unsupported models are left unchanged. Fast is independent from pi's reasoning/thinking level. When `models.dev` provides `experimental.modes.fast.cost`, the registered model cost switches to those Fast rates as well; the provider is refreshed when `/fast` is toggled. If no Fast price is published, the standard price is retained. The plugin does not guess Fast prices from `-pro`/`-fast` model IDs.
+Fast capability is catalog-driven: the plugin considers a CLIProxyAPI model Fast-capable when its `service_tiers` field is a non-empty array. The `additional_speed_tiers` field is ignored. For supported models, Fast injects `service_tier: "priority"`; unsupported models are left unchanged. Fast is independent from the host's reasoning/thinking level. When `models.dev` provides `experimental.modes.fast.cost`, the registered model cost switches to those Fast rates as well; the provider is refreshed when `/fast` is toggled. If no Fast price is published, the standard price is retained. The plugin does not guess Fast prices from `-pro`/`-fast` model IDs.
 
 ## Pausing provider requests
 
@@ -213,7 +219,7 @@ The raw `models.dev` response is cached for 24 hours at `~/.pi/agent/tmp/models-
 
 ## Migration from static models.json
 
-If you previously maintained a static provider such as `cpa-responses` in `~/.pi/agent/models.json`:
+If you previously maintained a static provider such as `cpa-responses` in `<agent-dir>/models.json`:
 
 1. Install this package and run `/login CLIProxyAPI` or `/login cliproxyapi` (or set `cliproxyapi.json`).
 2. Point `defaultProvider` / `enabledModels` at `cliproxyapi/<model-id>` (or set `providerId` to `cpa-responses` for a drop-in id).
@@ -227,7 +233,7 @@ The package also registers `extensions/tps.ts`, which only activates for the pri
 - When the agent settles, the footer keeps the final elapsed time and a notification reports approximate TPS plus token usage (`out` / `in` / cache r/w / total).
 - Subagent and print-mode sessions do not own the timer, clear the parent footer, or emit TPS toasts.
 
-Disable just this helper via `pi config` if you only want the CLIProxyAPI provider.
+Disable just this helper via `pi config` or `omp config` if you only want the CLIProxyAPI provider.
 
 ## Failure behavior
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ pi -e /absolute/path/to/pi-cliproxyapi-provider
 
 Below, `<agent-dir>` means `~/.pi/agent` for Pi or `~/.omp/agent` for OMP.
 
+Compatible-host limitation: Pi exposes `unregisterProvider`, so refresh and `/login` replace the prior registration. Current Oh My Pi does not; this extension re-registers in place and cannot clear stale merged fields (for example a previously registered ambient `apiKey`). Restart OMP after switching from config/env `apiKey` to `/login` credentials if the auth-type selector reappears.
+
 ## Login-style setup (recommended)
 
 This plugin needs both **baseUrl** and **apiKey**. The host's built-in `/login` uses the account/OAuth path for multi-field prompts, so CLIProxyAPI appears under **Sign in with an account** (not API key).
@@ -239,7 +241,7 @@ Disable just this helper via `pi config` or `omp config` if you only want the CL
 
 - CLIProxyAPI `closed network connection` responses are normalized as transient network errors so pi's agent-level retry policy reconnects and restarts the interrupted assistant turn. Completed conversation and tool results remain available; token streaming does not resume from the exact interruption point.
 - Before setup / without credentials: provider still appears in `/login`; no models are listed yet.
-- After successful `/login`: models are registered; credentials are stored in `auth.json` and mirrored to `cliproxyapi.json`.
+- After successful `/login`: models are registered; credentials are stored in `auth.json` and mirrored to `cliproxyapi.json`. On hosts without `unregisterProvider` (current Oh My Pi), this is a re-register, not a replace; stale merged fields are not cleared.
 - The built-in `/logout` command removes only the matching `auth.json` credential; environment variables and `cliproxyapi.json` are unchanged.
 - If a models request returns **HTTP 401** or CPA is unreachable during startup, an existing matching cache remains in use while the background refresh fails. Only when no cache is available is a warning logged; reconfigure via `/login CLIProxyAPI` or fix config/env.
 - Login final step validates credentials by requesting models:

--- a/extensions/codex-stream.ts
+++ b/extensions/codex-stream.ts
@@ -66,10 +66,15 @@ export function wrapStreamSimpleForFast(
 	shouldUseFast?: (model: Model<Api>) => boolean,
 ): CliproxyCodexStreamSimple {
 	return (model, context, streamOptions) => {
+		const hostSystemPrompt = (context as Context & { systemPrompt?: string | string[] }).systemPrompt;
+		const compatibleContext = Array.isArray(hostSystemPrompt)
+			? { ...context, systemPrompt: hostSystemPrompt.join("\n\n") }
+			: context;
+
 		if (!shouldUseFast?.(model)) {
-			return streamSimple(model, context, streamOptions);
+			return streamSimple(model, compatibleContext, streamOptions);
 		}
-		return streamSimple(model, context, {
+		return streamSimple(model, compatibleContext, {
 			...streamOptions,
 			onPayload: (payload, payloadModel) => applyFastPayloadHook(payload, payloadModel, streamOptions?.onPayload),
 		});

--- a/extensions/index.ts
+++ b/extensions/index.ts
@@ -364,7 +364,11 @@ function registerProvider(
 
 	// Replace any previous registration so an earlier ambient apiKey does not linger
 	// via registerProvider merge semantics and reintroduce the auth-type selector.
-	pi.unregisterProvider(providerId);
+	// Compatible hosts such as Oh My Pi may not expose unregisterProvider yet;
+	// their startup registration is still safe because no previous provider exists.
+	if (typeof pi.unregisterProvider === "function") {
+		pi.unregisterProvider(providerId);
+	}
 
 	pi.registerProvider(providerId, {
 		name: providerName,

--- a/extensions/index.ts
+++ b/extensions/index.ts
@@ -362,10 +362,15 @@ function registerProvider(
 		onFastModeChange,
 	});
 
-	// Replace any previous registration so an earlier ambient apiKey does not linger
-	// via registerProvider merge semantics and reintroduce the auth-type selector.
-	// Compatible hosts such as Oh My Pi may not expose unregisterProvider yet;
-	// their startup registration is still safe because no previous provider exists.
+	// Prefer replace: drop the previous registration so an earlier ambient apiKey
+	// cannot linger via registerProvider merge semantics and reintroduce the
+	// auth-type selector. This path runs on startup, /login, /cliproxyapi-refresh,
+	// and Fast-triggered catalog updates — not only first load.
+	// Hosts without unregisterProvider (current Oh My Pi) have no API to clear
+	// those merge fields. Do not invent an unregister. Re-register in place:
+	// first startup is still a clean insert; later refresh/login cannot drop
+	// stale fields the host already merged (restart the host after switching
+	// from config/env apiKey to /login credentials if the selector reappears).
 	if (typeof pi.unregisterProvider === "function") {
 		pi.unregisterProvider(providerId);
 	}

--- a/package.json
+++ b/package.json
@@ -1,11 +1,13 @@
 {
 	"name": "@router-for-me/pi-cliproxyapi-provider",
 	"version": "1.4.15",
-	"description": "Pi provider extension that auto-registers CLIProxyAPI models, plus TUI elapsed/TPS status",
+	"description": "Pi and Oh My Pi provider extension that auto-registers CLIProxyAPI models, plus TUI elapsed/TPS status",
 	"type": "module",
 	"keywords": [
 		"pi-package",
 		"pi-extension",
+		"omp-plugin",
+		"oh-my-pi",
 		"cliproxyapi",
 		"tps"
 	],
@@ -32,6 +34,12 @@
 		"check": "npm run typecheck && npm run lint && npm run test"
 	},
 	"pi": {
+		"extensions": [
+			"./extensions/index.ts",
+			"./extensions/tps.ts"
+		]
+	},
+	"omp": {
 		"extensions": [
 			"./extensions/index.ts",
 			"./extensions/tps.ts"

--- a/test/pi-compat.test.ts
+++ b/test/pi-compat.test.ts
@@ -1,9 +1,10 @@
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { Api, Model } from "@earendil-works/pi-ai";
+import type { Api, AssistantMessageEventStream, Context, Model } from "@earendil-works/pi-ai";
 import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { describe, expect, it, vi } from "vitest";
+import { type CliproxyCodexStreamSimple, wrapStreamSimpleForFast } from "../extensions/codex-stream.ts";
 import providerExtension from "../extensions/index.ts";
 import { AUTH_FILE_NAME } from "../extensions/lib.ts";
 
@@ -77,6 +78,38 @@ function createPiMock(commands: Map<string, Parameters<ExtensionAPI["registerCom
 }
 
 describe("pi 0.82.0 compatibility", () => {
+	it("normalizes OMP system prompt arrays before invoking the Pi Codex stream", () => {
+		const eventStream = {} as AssistantMessageEventStream;
+		const delegate = vi.fn(() => eventStream) as unknown as CliproxyCodexStreamSimple;
+		const wrapped = wrapStreamSimpleForFast(delegate);
+		const model = { id: "gpt-5.6-sol", provider: "cliproxyapi" } as Model<Api>;
+		const context = {
+			systemPrompt: ["first instruction", "second instruction"],
+			messages: [],
+		} as unknown as Context;
+
+		expect(wrapped(model, context)).toBe(eventStream);
+		expect(delegate).toHaveBeenCalledWith(
+			model,
+			{ ...context, systemPrompt: "first instruction\n\nsecond instruction" },
+			undefined,
+		);
+	});
+
+	it("loads on compatible hosts that do not implement unregisterProvider", async () => {
+		await withTempAgentDir(async () => {
+			const commands = new Map<string, Parameters<ExtensionAPI["registerCommand"]>[1]>();
+			const { pi } = createPiMock(commands);
+			Reflect.deleteProperty(pi as object, "unregisterProvider");
+
+			await expect(providerExtension(pi)).resolves.toBeUndefined();
+			expect(pi.registerProvider).toHaveBeenCalledWith(
+				"cliproxyapi",
+				expect.objectContaining({ name: "CLIProxyAPI" }),
+			);
+		});
+	});
+
 	it("registers oauth login and /fast without a dedicated /cliproxyapi command", async () => {
 		await withTempAgentDir(async () => {
 			const commands = new Map<string, Parameters<ExtensionAPI["registerCommand"]>[1]>();

--- a/test/pi-compat.test.ts
+++ b/test/pi-compat.test.ts
@@ -110,6 +110,44 @@ describe("pi 0.82.0 compatibility", () => {
 		});
 	});
 
+	it("re-registers in place on hosts without unregisterProvider", async () => {
+		await withTempAgentDir(async (agentDir) => {
+			writeFileSync(
+				join(agentDir, "cliproxyapi.json"),
+				JSON.stringify({ baseUrl: "http://127.0.0.1:8317", apiKey: "ambient-key" }),
+				"utf8",
+			);
+
+			const commands = new Map<string, Parameters<ExtensionAPI["registerCommand"]>[1]>();
+			const { pi } = createPiMock(commands);
+			Reflect.deleteProperty(pi as object, "unregisterProvider");
+			const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(JSON.stringify({ models: [] }), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				}),
+			);
+
+			try {
+				await expect(providerExtension(pi)).resolves.toBeUndefined();
+				const registerCallsAfterLoad = (pi.registerProvider as ReturnType<typeof vi.fn>).mock.calls.length;
+				expect(registerCallsAfterLoad).toBeGreaterThan(0);
+				expect("unregisterProvider" in pi).toBe(false);
+
+				const refresh = commands.get("cliproxyapi-refresh");
+				if (!refresh) throw new Error("cliproxyapi-refresh command is unavailable");
+				await refresh.handler("", { ui: { notify: vi.fn() } } as unknown as ExtensionCommandContext);
+
+				// Without unregisterProvider the host cannot replace; refresh only
+				// re-registers. Stale merged fields are a documented host limitation.
+				expect(pi.registerProvider).toHaveBeenCalledTimes(registerCallsAfterLoad + 1);
+				expect("unregisterProvider" in pi).toBe(false);
+			} finally {
+				fetchMock.mockRestore();
+			}
+		});
+	});
+
 	it("registers oauth login and /fast without a dedicated /cliproxyapi command", async () => {
 		await withTempAgentDir(async () => {
 			const commands = new Map<string, Parameters<ExtensionAPI["registerCommand"]>[1]>();


### PR DESCRIPTION
Closes #1.

## Summary

- guard `unregisterProvider` for compatible hosts that do not expose it
- normalize OMP's `string[]` system prompt before delegating to the Pi Codex stream
- add focused compatibility tests
- minimally document OMP installation, paths, and package support

## Validation

- `npm run check` — 47/47 tests pass
- OMP discovers 110 CLIProxyAPI models without extension errors
- real OMP request through `cliproxyapi/gpt-5.6-sol` succeeds
- real Pi request through `cliproxyapi/gpt-5.6-sol` succeeds
