### PR TITLE
perf: cache model catalog to avoid blocking startup on /v1/models

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Pi provider extension that discovers models from [CLIProxyAPI](https://github.co
 4. Maps the CLIProxyAPI catalog into pi models, including Fast service-tier capability.
 5. Registers inference against `{root}/backend-api/`.
 6. Provides `/fast` to toggle OpenAI priority processing for supported models.
-7. In interactive TUI sessions, shows footer elapsed time during runs and a TPS / token usage toast when the agent settles.
+7. Caches the model catalog in `~/.pi/agent/cliproxyapi-models.json` with a 24-hour TTL and provides `/cliproxyapi-refresh` to force a refresh.
+8. In interactive TUI sessions, shows footer elapsed time during runs and a TPS / token usage toast when the agent settles.
 
 ## Install
 
@@ -58,9 +59,9 @@ Then choose:
    - base URL — preferred form is host:port, e.g. `http://127.0.0.1:8317`
    - API key
 
-Final login validation calls `{root}/v1/models?client_version=pi`:
+Final login validation calls `{root}/v1/models?client_version=pi` (this always bypasses the model cache and forces a fresh remote query):
 
-- **HTTP 200** → login succeeds (empty model list is still OK)
+- **HTTP 200** → login succeeds (empty model list is still OK) and the model cache is rewritten
 - **non-200 / network error** → login fails and you are prompted to re-enter base URL + API key
 
 On success:
@@ -145,6 +146,39 @@ When Fast is effective, pi's model status appends a yellow lowercase `fast`, for
 
 Fast capability is catalog-driven: the plugin considers a CLIProxyAPI model Fast-capable when its `service_tiers` field is a non-empty array. The `additional_speed_tiers` field is ignored. For supported models, Fast injects `service_tier: "priority"`; unsupported models are left unchanged. Fast is independent from pi's reasoning/thinking level.
 
+## Model cache
+
+The provider keeps a separate cache file so startup stays fast when CLIProxyAPI is slow or briefly unreachable:
+
+`~/.pi/agent/cliproxyapi-models.json`
+
+The cache stores only model metadata and derived endpoint URLs — the model list, Fast-capable IDs, `inferenceBaseUrl`, `modelsUrl`, and a `fetchedAt` timestamp. It **never** stores your API key or other credentials.
+
+| Property | Value |
+|----------|-------|
+| Cache file | `~/.pi/agent/cliproxyapi-models.json` |
+| TTL | 24 hours |
+| Remote query timeout | 3 seconds |
+| Scope | tied to the current `baseUrl` (a different base URL ignores the existing cache) |
+
+### Startup / resume behavior
+
+When the provider loads (including session resume):
+
+1. If a **fresh** cache exists (age < 24 h) for the configured `baseUrl`, models are registered immediately from the cache and **no remote request is made** — startup stays fully offline.
+2. Otherwise (cache missing, stale, or scoped to a different `baseUrl`), a remote query to `{root}/v1/models?client_version=pi` is attempted with a 3-second timeout.
+   - On success, the cache is rewritten and the freshly fetched models are registered.
+   - On failure (network error, non-200, or timeout), the provider falls back to the stale cache if one exists (even if expired) and registers those models. If no cache is available, startup behaves as before: a warning is logged and no models are registered until the proxy responds.
+
+Use `/cliproxyapi-refresh` to refresh a fresh cache on demand.
+
+### Refresh commands
+
+- `/cliproxyapi-refresh` — force an immediate remote refresh of the model catalog, rewrite the cache, and update registered models. Use this after adding or removing models on the proxy without restarting pi.
+- `/login CLIProxyAPI` / `/login cliproxyapi` — re-entering credentials always forces a fresh models query and rewrites the cache.
+
+Delete `~/.pi/agent/cliproxyapi-models.json` to clear the cache manually.
+
 ## Model mapping
 
 From CPA catalog entry → pi model:
@@ -183,7 +217,7 @@ Disable just this helper via `pi config` if you only want the CLIProxyAPI provid
 - Before setup / without credentials: provider still appears in `/login`; no models are listed yet.
 - After successful `/login`: models are registered; credentials are stored in `auth.json` and mirrored to `cliproxyapi.json`.
 - The built-in `/logout` command removes only the matching `auth.json` credential; environment variables and `cliproxyapi.json` are unchanged.
-- If a models request returns **HTTP 401** or CPA is unreachable during startup, a warning is logged; reconfigure via `/login CLIProxyAPI` or fix config/env.
+- If a models request returns **HTTP 401** or CPA is unreachable during startup, the provider falls back to the cached catalog if one exists (even stale). Only when no cache is available is a warning logged; reconfigure via `/login CLIProxyAPI` or fix config/env.
 - Login final step validates credentials by requesting models:
   - HTTP 200 (including empty catalog) → credentials are persisted
   - non-200 / network / invalid baseUrl → nothing is persisted; re-enter baseUrl + API key

--- a/extensions/index.ts
+++ b/extensions/index.ts
@@ -33,12 +33,13 @@ import {
 	isUnauthorizedModelsError,
 	loadAuthConnection,
 	loadConfigFile,
-	loadMappedModels,
+	type ModelsCacheFile,
 	type PiProviderModel,
 	resolveConnection,
 	resolveEndpoints,
 	resolveFastDefault,
 	resolveIdentity,
+	resolveMappedModels,
 	saveConfigFile,
 } from "./lib.ts";
 
@@ -141,7 +142,7 @@ async function configureAndRegister(options: {
 	const { pi, agentDir, providerId, providerName, baseUrlInput, apiKey, defaultBaseUrl, streamSimple, fastMode } =
 		options;
 
-	const loaded = await loadMappedModels(baseUrlInput, apiKey);
+	const { loaded } = await resolveMappedModels(agentDir, baseUrlInput, apiKey, { forceRefresh: true });
 
 	try {
 		saveConfigFile(agentDir, {
@@ -340,6 +341,62 @@ export function registerFastCommand(options: {
 	});
 }
 
+export function registerRefreshCommand(options: {
+	pi: ExtensionAPI;
+	agentDir: string;
+	providerId: string;
+	providerName: string;
+	defaultBaseUrl: string;
+	streamSimple: CliproxyCodexStreamSimple;
+	fastMode: FastModeController;
+}): void {
+	const { pi, agentDir, providerId, providerName, defaultBaseUrl, streamSimple, fastMode } = options;
+
+	pi.registerCommand("cliproxyapi-refresh", {
+		description: "Force refresh CLIProxyAPI models from the remote catalog.",
+		handler: async (args, ctx) => {
+			if (args.trim()) {
+				ctx.ui.notify("Usage: /cliproxyapi-refresh", "error");
+				return;
+			}
+
+			const connection = resolveConnection(agentDir, providerId);
+			if (!connection) {
+				ctx.ui.notify(
+					`CLIProxyAPI is not configured. Use /login ${providerName} or /login ${providerId}.`,
+					"error",
+				);
+				return;
+			}
+
+			try {
+				const { loaded } = await resolveMappedModels(agentDir, connection.baseUrlInput, connection.apiKey, {
+					forceRefresh: true,
+				});
+				fastMode.setSupportedModelIds(loaded.fastModelIds);
+
+				const hasStoredLogin = hasLoginCredential(agentDir, providerId);
+				registerProvider(pi, {
+					providerId,
+					providerName,
+					baseUrlInput: connection.baseUrlInput,
+					apiKey: hasStoredLogin ? undefined : connection.apiKey,
+					models: loaded.models,
+					defaultBaseUrl,
+					agentDir,
+					streamSimple,
+					fastMode,
+				});
+
+				ctx.ui.notify(`Refreshed ${loaded.models.length} CLIProxyAPI models from ${loaded.modelsUrl}.`, "info");
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				ctx.ui.notify(`Failed to refresh CLIProxyAPI models: ${message}`, "error");
+			}
+		},
+	});
+}
+
 export { CLIPROXYAPI_CODEX_API } from "./codex-stream.ts";
 export { resolveEndpoints, toPiModel } from "./lib.ts";
 
@@ -377,6 +434,15 @@ export default async function (pi: ExtensionAPI): Promise<void> {
 		fastMode,
 		onStatusChange: (ctx) => fastFooter.refresh(ctx),
 	});
+	registerRefreshCommand({
+		pi,
+		agentDir,
+		providerId: identity.providerId,
+		providerName: identity.providerName,
+		defaultBaseUrl,
+		streamSimple,
+		fastMode,
+	});
 	fastFooter.register(pi);
 
 	// Always register oauth so the provider is visible in /login immediately after install.
@@ -401,8 +467,27 @@ export default async function (pi: ExtensionAPI): Promise<void> {
 	}
 
 	try {
-		const loaded = await loadMappedModels(connection.baseUrlInput, connection.apiKey);
+		const { loaded, fromCache, stale } = await resolveMappedModels(
+			agentDir,
+			connection.baseUrlInput,
+			connection.apiKey,
+		);
 		fastMode.setSupportedModelIds(loaded.fastModelIds);
+
+		if (fromCache) {
+			if (stale) {
+				const fetchedAt = (loaded as ModelsCacheFile).fetchedAt;
+				logWarn(
+					`using stale model cache from ${new Date(fetchedAt).toISOString()}; ` +
+						`use /cliproxyapi-refresh to update.`,
+				);
+			} else {
+				logInfo(`using fresh model cache (${loaded.models.length} models)`);
+			}
+		} else {
+			logInfo(`fetched ${loaded.models.length} models from ${loaded.modelsUrl}`);
+		}
+
 		// Prefer OAuth-only registration when /login already stored credentials so
 		// `/login <provider>` jumps straight into the multi-field flow. Fall back to
 		// ambient apiKey only for config-file / env setups without auth.json.

--- a/extensions/index.ts
+++ b/extensions/index.ts
@@ -474,18 +474,12 @@ export default async function (pi: ExtensionAPI): Promise<void> {
 		);
 		fastMode.setSupportedModelIds(loaded.fastModelIds);
 
-		if (fromCache) {
-			if (stale) {
-				const fetchedAt = (loaded as ModelsCacheFile).fetchedAt;
-				logWarn(
-					`using stale model cache from ${new Date(fetchedAt).toISOString()}; ` +
-						`use /cliproxyapi-refresh to update.`,
-				);
-			} else {
-				logInfo(`using fresh model cache (${loaded.models.length} models)`);
-			}
-		} else {
-			logInfo(`fetched ${loaded.models.length} models from ${loaded.modelsUrl}`);
+		if (fromCache && stale) {
+			const fetchedAt = (loaded as ModelsCacheFile).fetchedAt;
+			logWarn(
+				`using stale model cache from ${new Date(fetchedAt).toISOString()}; ` +
+					`use /cliproxyapi-refresh to update.`,
+			);
 		}
 
 		// Prefer OAuth-only registration when /login already stored credentials so

--- a/extensions/lib.ts
+++ b/extensions/lib.ts
@@ -15,8 +15,11 @@ export const DEFAULT_PROVIDER_ID = "cliproxyapi";
 export const DEFAULT_PROVIDER_NAME = "CLIProxyAPI";
 export const DEFAULT_BASE_URL = "http://127.0.0.1:8317";
 export const CONFIG_FILE_NAME = "cliproxyapi.json";
+export const MODELS_CACHE_FILE_NAME = "cliproxyapi-models.json";
 export const AUTH_FILE_NAME = "auth.json";
 export const CLIENT_VERSION = "pi";
+export const MODELS_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+export const MODELS_REQUEST_TIMEOUT_MS = 3000;
 
 /** Keep login credentials effectively permanent; reconfigure via /login. */
 export const CREDENTIAL_TTL_MS = 100 * 365 * 24 * 60 * 60 * 1000;
@@ -88,6 +91,17 @@ export interface PiProviderModel {
 	contextWindow: number;
 	maxTokens: number;
 	thinkingLevelMap?: ThinkingLevelMap;
+}
+
+export interface MappedModels {
+	models: PiProviderModel[];
+	fastModelIds: string[];
+	inferenceBaseUrl: string;
+	modelsUrl: string;
+}
+
+export interface ModelsCacheFile extends MappedModels {
+	fetchedAt: number;
 }
 
 export interface OAuthRefreshMeta {
@@ -197,6 +211,36 @@ export function saveConfigFile(agentDir: string, config: CliproxyConfigFile): vo
 		...config,
 	};
 	writeFileSync(configPath, `${JSON.stringify(next, null, 2)}\n`, "utf8");
+}
+
+export function loadModelsCache(agentDir: string, baseUrlInput: string): ModelsCacheFile | null {
+	const cachePath = join(agentDir, MODELS_CACHE_FILE_NAME);
+	try {
+		const parsed = JSON.parse(readFileSync(cachePath, "utf8")) as Partial<ModelsCacheFile>;
+		const endpoints = resolveEndpoints(baseUrlInput);
+		if (
+			typeof parsed.fetchedAt !== "number" ||
+			parsed.modelsUrl !== endpoints.modelsUrl ||
+			parsed.inferenceBaseUrl !== endpoints.inferenceBaseUrl ||
+			!Array.isArray(parsed.models) ||
+			!Array.isArray(parsed.fastModelIds)
+		) {
+			return null;
+		}
+		return parsed as ModelsCacheFile;
+	} catch {
+		return null;
+	}
+}
+
+export function isModelsCacheFresh(cache: ModelsCacheFile, now = Date.now()): boolean {
+	return now - cache.fetchedAt < MODELS_CACHE_TTL_MS;
+}
+
+export function saveModelsCache(agentDir: string, loaded: MappedModels, fetchedAt = Date.now()): void {
+	const cachePath = join(agentDir, MODELS_CACHE_FILE_NAME);
+	mkdirSync(dirname(cachePath), { recursive: true });
+	writeFileSync(cachePath, `${JSON.stringify({ ...loaded, fetchedAt }, null, 2)}\n`, "utf8");
 }
 
 export function loadAuthConnection(agentDir: string, providerId: string): { baseUrl?: string; apiKey?: string } | null {
@@ -404,12 +448,17 @@ export function isUnauthorizedModelsError(error: unknown): boolean {
 	return error instanceof ModelsHttpError && error.status === 401;
 }
 
-export async function fetchCodexModels(modelsUrl: string, apiKey: string): Promise<CodexClientModel[]> {
+export async function fetchCodexModels(
+	modelsUrl: string,
+	apiKey: string,
+	timeoutMs = MODELS_REQUEST_TIMEOUT_MS,
+): Promise<CodexClientModel[]> {
 	const response = await fetch(modelsUrl, {
 		headers: {
 			Authorization: `Bearer ${apiKey}`,
 			Accept: "application/json",
 		},
+		signal: AbortSignal.timeout(timeoutMs),
 	});
 
 	// Login validation only requires HTTP 200; non-2xx means credentials/baseUrl failed.
@@ -441,12 +490,19 @@ export async function fetchCodexModels(modelsUrl: string, apiKey: string): Promi
 	return [];
 }
 
+export interface ResolvedModelsResult {
+	loaded: MappedModels;
+	fromCache: boolean;
+	stale?: boolean;
+}
+
 export async function loadMappedModels(
 	baseUrlInput: string,
 	apiKey: string,
-): Promise<{ models: PiProviderModel[]; fastModelIds: string[]; inferenceBaseUrl: string; modelsUrl: string }> {
+	timeoutMs = MODELS_REQUEST_TIMEOUT_MS,
+): Promise<MappedModels> {
 	const endpoints = resolveEndpoints(baseUrlInput);
-	const remoteModels = await fetchCodexModels(endpoints.modelsUrl, apiKey);
+	const remoteModels = await fetchCodexModels(endpoints.modelsUrl, apiKey, timeoutMs);
 	const models = remoteModels.map(toPiModel).filter((model): model is PiProviderModel => model !== null);
 	const fastModelIds = Array.from(
 		new Set(
@@ -464,4 +520,37 @@ export async function loadMappedModels(
 		inferenceBaseUrl: endpoints.inferenceBaseUrl,
 		modelsUrl: endpoints.modelsUrl,
 	};
+}
+
+/**
+ * Load mapped models from fresh cache, or fetch remotely and update the cache.
+ * When the remote fetch fails and a stale cache exists, the stale cache is
+ * returned so the provider can keep working offline.
+ */
+export async function resolveMappedModels(
+	agentDir: string,
+	baseUrlInput: string,
+	apiKey: string,
+	options: { forceRefresh?: boolean; timeoutMs?: number } = {},
+): Promise<ResolvedModelsResult> {
+	if (!options.forceRefresh) {
+		const cache = loadModelsCache(agentDir, baseUrlInput);
+		if (cache && isModelsCacheFresh(cache)) {
+			return { loaded: cache, fromCache: true };
+		}
+	}
+
+	try {
+		const loaded = await loadMappedModels(baseUrlInput, apiKey, options.timeoutMs);
+		saveModelsCache(agentDir, loaded);
+		return { loaded, fromCache: false };
+	} catch (error) {
+		if (!options.forceRefresh) {
+			const staleCache = loadModelsCache(agentDir, baseUrlInput);
+			if (staleCache) {
+				return { loaded: staleCache, fromCache: true, stale: true };
+			}
+		}
+		throw error;
+	}
 }

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -1,0 +1,560 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Api, Model } from "@earendil-works/pi-ai";
+import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import providerExtension from "../extensions/index.ts";
+import {
+	CONFIG_FILE_NAME,
+	fetchCodexModels,
+	isModelsCacheFresh,
+	loadMappedModels,
+	loadModelsCache,
+	type MappedModels,
+	MODELS_CACHE_FILE_NAME,
+	MODELS_CACHE_TTL_MS,
+	MODELS_REQUEST_TIMEOUT_MS,
+	type PiProviderModel,
+	resolveEndpoints,
+	resolveMappedModels,
+	saveModelsCache,
+} from "../extensions/lib.ts";
+
+const CLIPROXYAPI_ENV_NAMES = [
+	"CLIPROXYAPI_API_KEY",
+	"CLIPROXYAPI_BASE_URL",
+	"CLIPROXYAPI_FAST",
+	"CLIPROXYAPI_PROVIDER_ID",
+	"CLIPROXYAPI_PROVIDER_NAME",
+] as const;
+
+function createModel(id: string): PiProviderModel {
+	return {
+		id,
+		name: id,
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128000,
+		maxTokens: 16384,
+	};
+}
+
+function createCodexModel(id: string, fast = false) {
+	return {
+		slug: id,
+		display_name: id,
+		input_modalities: ["text"],
+		...(fast ? { service_tiers: [{ id: "priority", name: "Fast" }] } : {}),
+	};
+}
+
+function createMappedModels(options: { models?: PiProviderModel[]; fastModelIds?: string[] } = {}): MappedModels {
+	const endpoints = resolveEndpoints("http://127.0.0.1:8317");
+	return {
+		models: options.models ?? [],
+		fastModelIds: options.fastModelIds ?? [],
+		inferenceBaseUrl: endpoints.inferenceBaseUrl,
+		modelsUrl: endpoints.modelsUrl,
+	};
+}
+
+const tempPaths: string[] = [];
+
+function tempAgentDir(): string {
+	const dir = mkdtempSync(join(tmpdir(), "pi-cliproxyapi-cache-test-"));
+	tempPaths.push(dir);
+	return dir;
+}
+
+function writeConfig(agentDir: string, config: { baseUrl?: string; apiKey?: string }): void {
+	writeFileSync(join(agentDir, CONFIG_FILE_NAME), JSON.stringify(config, null, 2), "utf8");
+}
+
+async function withTempAgentDir(run: (agentDir: string) => Promise<void>): Promise<void> {
+	const agentDir = tempAgentDir();
+	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	const previousEnv = new Map(CLIPROXYAPI_ENV_NAMES.map((name) => [name, process.env[name]]));
+	process.env.PI_CODING_AGENT_DIR = agentDir;
+	for (const name of CLIPROXYAPI_ENV_NAMES) delete process.env[name];
+
+	try {
+		await run(agentDir);
+	} finally {
+		if (previousAgentDir === undefined) {
+			delete process.env.PI_CODING_AGENT_DIR;
+		} else {
+			process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+		}
+		for (const [name, value] of previousEnv) {
+			if (value === undefined) {
+				delete process.env[name];
+			} else {
+				process.env[name] = value;
+			}
+		}
+	}
+}
+
+function createPiMock(commands = new Map<string, Parameters<ExtensionAPI["registerCommand"]>[1]>()): {
+	pi: ExtensionAPI;
+	commands: Map<string, Parameters<ExtensionAPI["registerCommand"]>[1]>;
+} {
+	const pi = {
+		registerCommand: vi.fn((name: string, options: Parameters<ExtensionAPI["registerCommand"]>[1]) => {
+			commands.set(name, options);
+		}),
+		unregisterProvider: vi.fn(),
+		registerProvider: vi.fn(),
+		on: vi.fn(),
+	} as unknown as ExtensionAPI;
+	return { pi, commands };
+}
+
+afterEach(() => {
+	while (tempPaths.length > 0) {
+		const path = tempPaths.pop();
+		if (path) rmSync(path, { recursive: true, force: true });
+	}
+});
+
+describe("models cache helpers", () => {
+	it("save and load round-trip cache when endpoints match", () => {
+		const agentDir = tempAgentDir();
+		const loaded = createMappedModels({
+			models: [createModel("cached-model")],
+			fastModelIds: ["fast-model"],
+		});
+		const fetchedAt = Date.now() - 60 * 60 * 1000;
+
+		saveModelsCache(agentDir, loaded, fetchedAt);
+		const cache = loadModelsCache(agentDir, "http://127.0.0.1:8317");
+
+		expect(cache).toEqual({ ...loaded, fetchedAt });
+		expect(isModelsCacheFresh(cache!)).toBe(true);
+	});
+
+	it("returns null when the cache file is missing", () => {
+		const agentDir = tempAgentDir();
+		expect(loadModelsCache(agentDir, "http://127.0.0.1:8317")).toBeNull();
+	});
+
+	it("returns null when the cached endpoint URLs do not match", () => {
+		const agentDir = tempAgentDir();
+		const loaded = createMappedModels({ models: [createModel("m1")] });
+		saveModelsCache(agentDir, loaded, Date.now());
+
+		expect(loadModelsCache(agentDir, "http://127.0.0.1:9999")).toBeNull();
+	});
+
+	it("matches cache across equivalent baseUrl forms", () => {
+		const agentDir = tempAgentDir();
+		const loaded = createMappedModels({ models: [createModel("m1")] });
+		const fetchedAt = Date.now();
+		saveModelsCache(agentDir, loaded, fetchedAt);
+
+		expect(loadModelsCache(agentDir, "127.0.0.1:8317")).toEqual({ ...loaded, fetchedAt });
+		expect(loadModelsCache(agentDir, "http://127.0.0.1:8317/")).toEqual({ ...loaded, fetchedAt });
+		expect(loadModelsCache(agentDir, "http://127.0.0.1:8317/v1")).toEqual({ ...loaded, fetchedAt });
+	});
+
+	it("writes pretty-printed JSON to disk", () => {
+		const agentDir = tempAgentDir();
+		const loaded = createMappedModels({ models: [createModel("m1")] });
+		saveModelsCache(agentDir, loaded, 12345);
+
+		const raw = readFileSync(join(agentDir, MODELS_CACHE_FILE_NAME), "utf8");
+		expect(raw.endsWith("\n")).toBe(true);
+		expect(JSON.parse(raw)).toEqual({ ...loaded, fetchedAt: 12345 });
+	});
+});
+
+describe("fresh/stale cache detection", () => {
+	const now = 1_700_000_000_000;
+
+	it("is fresh when age is strictly less than 24h", () => {
+		const cache = { ...createMappedModels(), fetchedAt: now - MODELS_CACHE_TTL_MS + 1 };
+		expect(isModelsCacheFresh(cache, now)).toBe(true);
+	});
+
+	it("is stale at exactly 24h", () => {
+		const cache = { ...createMappedModels(), fetchedAt: now - MODELS_CACHE_TTL_MS };
+		expect(isModelsCacheFresh(cache, now)).toBe(false);
+	});
+
+	it("is stale beyond 24h", () => {
+		const cache = { ...createMappedModels(), fetchedAt: now - MODELS_CACHE_TTL_MS - 1 };
+		expect(isModelsCacheFresh(cache, now)).toBe(false);
+	});
+});
+
+describe("models request timeout wiring", () => {
+	beforeEach(() => {
+		vi.useFakeTimers({ shouldAdvanceTime: true });
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("uses a 3s timeout by default", async () => {
+		const timeoutSpy = vi.spyOn(globalThis.AbortSignal, "timeout");
+		const fetchMock = vi
+			.spyOn(globalThis, "fetch")
+			.mockResolvedValue(new Response(JSON.stringify({ models: [] }), { status: 200 }));
+
+		try {
+			await loadMappedModels("http://127.0.0.1:8317", "key");
+			expect(MODELS_REQUEST_TIMEOUT_MS).toBe(3000);
+			expect(timeoutSpy).toHaveBeenCalledWith(3000);
+			expect(timeoutSpy).toHaveBeenCalledTimes(1);
+		} finally {
+			fetchMock.mockRestore();
+			timeoutSpy.mockRestore();
+		}
+	});
+
+	it("allows the caller to override the timeout", async () => {
+		const timeoutSpy = vi.spyOn(globalThis.AbortSignal, "timeout");
+		const fetchMock = vi
+			.spyOn(globalThis, "fetch")
+			.mockResolvedValue(new Response(JSON.stringify({ models: [] }), { status: 200 }));
+
+		try {
+			await loadMappedModels("http://127.0.0.1:8317", "key", 750);
+			expect(timeoutSpy).toHaveBeenCalledWith(750);
+			expect(timeoutSpy).toHaveBeenCalledTimes(1);
+		} finally {
+			fetchMock.mockRestore();
+			timeoutSpy.mockRestore();
+		}
+	});
+
+	it("propagates a custom timeout through fetchCodexModels", async () => {
+		const timeoutSpy = vi.spyOn(globalThis.AbortSignal, "timeout");
+		const fetchMock = vi
+			.spyOn(globalThis, "fetch")
+			.mockResolvedValue(new Response(JSON.stringify({ models: [] }), { status: 200 }));
+
+		try {
+			await fetchCodexModels("http://127.0.0.1:8317/v1/models?client_version=pi", "key", 500);
+			expect(timeoutSpy).toHaveBeenCalledWith(500);
+		} finally {
+			fetchMock.mockRestore();
+			timeoutSpy.mockRestore();
+		}
+	});
+});
+
+describe("resolveMappedModels cache behavior", () => {
+	it("returns fresh cache without fetching", async () => {
+		const agentDir = tempAgentDir();
+		const cached = createMappedModels({ models: [createModel("cached")], fastModelIds: ["fast-cached"] });
+		saveModelsCache(agentDir, cached, Date.now() - 60 * 60 * 1000);
+
+		const fetchMock = vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("should not fetch"));
+
+		try {
+			const result = await resolveMappedModels(agentDir, "http://127.0.0.1:8317", "key");
+			expect(fetchMock).not.toHaveBeenCalled();
+			expect(result.fromCache).toBe(true);
+			expect(result.stale).toBeUndefined();
+			expect(result.loaded.models).toEqual(cached.models);
+			expect(result.loaded.fastModelIds).toEqual(["fast-cached"]);
+		} finally {
+			fetchMock.mockRestore();
+		}
+	});
+
+	it("fetches remotely when no cache exists", async () => {
+		const agentDir = tempAgentDir();
+		const fetchMock = vi
+			.spyOn(globalThis, "fetch")
+			.mockResolvedValue(new Response(JSON.stringify({ models: [createCodexModel("remote")] }), { status: 200 }));
+
+		try {
+			const result = await resolveMappedModels(agentDir, "http://127.0.0.1:8317", "key");
+			expect(fetchMock).toHaveBeenCalledTimes(1);
+			expect(result.fromCache).toBe(false);
+			expect(result.loaded.models.map((model) => model.id)).toEqual(["remote"]);
+			const diskCache = loadModelsCache(agentDir, "http://127.0.0.1:8317");
+			expect(diskCache?.models[0].id).toBe("remote");
+			expect(isModelsCacheFresh(diskCache!)).toBe(true);
+		} finally {
+			fetchMock.mockRestore();
+		}
+	});
+
+	it("forceRefresh bypasses even a fresh cache", async () => {
+		const agentDir = tempAgentDir();
+		const cached = createMappedModels({ models: [createModel("cached")] });
+		saveModelsCache(agentDir, cached, Date.now());
+
+		const fetchMock = vi
+			.spyOn(globalThis, "fetch")
+			.mockResolvedValue(new Response(JSON.stringify({ models: [createCodexModel("forced")] }), { status: 200 }));
+
+		try {
+			const result = await resolveMappedModels(agentDir, "http://127.0.0.1:8317", "key", {
+				forceRefresh: true,
+			});
+			expect(fetchMock).toHaveBeenCalledTimes(1);
+			expect(result.fromCache).toBe(false);
+			expect(result.loaded.models[0].id).toBe("forced");
+		} finally {
+			fetchMock.mockRestore();
+		}
+	});
+
+	it("refreshes a stale cache when the remote call succeeds", async () => {
+		const agentDir = tempAgentDir();
+		const stale = createMappedModels({ models: [createModel("stale")] });
+		saveModelsCache(agentDir, stale, Date.now() - MODELS_CACHE_TTL_MS - 1000);
+
+		const fetchMock = vi
+			.spyOn(globalThis, "fetch")
+			.mockResolvedValue(new Response(JSON.stringify({ models: [createCodexModel("fresh")] }), { status: 200 }));
+
+		try {
+			const result = await resolveMappedModels(agentDir, "http://127.0.0.1:8317", "key");
+			expect(fetchMock).toHaveBeenCalledTimes(1);
+			expect(result.fromCache).toBe(false);
+			expect(result.loaded.models[0].id).toBe("fresh");
+			const diskCache = loadModelsCache(agentDir, "http://127.0.0.1:8317");
+			expect(diskCache?.models[0].id).toBe("fresh");
+			expect(isModelsCacheFresh(diskCache!)).toBe(true);
+		} finally {
+			fetchMock.mockRestore();
+		}
+	});
+
+	it("falls back to a stale cache when the remote call fails", async () => {
+		const agentDir = tempAgentDir();
+		const stale = createMappedModels({ models: [createModel("stale-fallback")] });
+		saveModelsCache(agentDir, stale, Date.now() - MODELS_CACHE_TTL_MS - 1000);
+
+		const fetchMock = vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("network down"));
+
+		try {
+			const result = await resolveMappedModels(agentDir, "http://127.0.0.1:8317", "key");
+			expect(fetchMock).toHaveBeenCalledTimes(1);
+			expect(result.fromCache).toBe(true);
+			expect(result.stale).toBe(true);
+			expect(result.loaded.models[0].id).toBe("stale-fallback");
+		} finally {
+			fetchMock.mockRestore();
+		}
+	});
+
+	it("does not fall back when forceRefresh is requested and the remote call fails", async () => {
+		const agentDir = tempAgentDir();
+		const stale = createMappedModels({ models: [createModel("stale")] });
+		saveModelsCache(agentDir, stale, Date.now() - MODELS_CACHE_TTL_MS - 1000);
+
+		const fetchMock = vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("network down"));
+
+		try {
+			await expect(
+				resolveMappedModels(agentDir, "http://127.0.0.1:8317", "key", { forceRefresh: true }),
+			).rejects.toThrow("network down");
+			expect(fetchMock).toHaveBeenCalledTimes(1);
+		} finally {
+			fetchMock.mockRestore();
+		}
+	});
+});
+
+describe("provider startup cache behavior", () => {
+	it("uses a fresh cache on startup and does not fetch", async () => {
+		await withTempAgentDir(async (agentDir) => {
+			writeConfig(agentDir, { baseUrl: "http://127.0.0.1:8317", apiKey: "key" });
+			const cached = createMappedModels({
+				models: [createModel("startup-cached")],
+				fastModelIds: ["startup-fast"],
+			});
+			saveModelsCache(agentDir, cached, Date.now() - 60 * 60 * 1000);
+
+			const fetchMock = vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("should not fetch"));
+			const { pi, commands } = createPiMock();
+
+			try {
+				await expect(providerExtension(pi)).resolves.toBeUndefined();
+				expect(fetchMock).not.toHaveBeenCalled();
+				expect(commands.has("cliproxyapi-refresh")).toBe(true);
+
+				const callsWithModels = (
+					(pi.registerProvider as ReturnType<typeof vi.fn>).mock.calls as Array<
+						[string, { models?: PiProviderModel[] }]
+					>
+				).filter(([, config]) => config.models && config.models.length > 0);
+				expect(callsWithModels.length).toBeGreaterThan(0);
+				expect(callsWithModels[0]?.[1].models?.map((model: PiProviderModel) => model.id)).toEqual([
+					"startup-cached",
+				]);
+			} finally {
+				fetchMock.mockRestore();
+			}
+		});
+	});
+
+	it("refreshes a stale cache on startup and registers the new models", async () => {
+		await withTempAgentDir(async (agentDir) => {
+			writeConfig(agentDir, { baseUrl: "http://127.0.0.1:8317", apiKey: "key" });
+			const stale = createMappedModels({ models: [createModel("stale-startup")] });
+			saveModelsCache(agentDir, stale, Date.now() - MODELS_CACHE_TTL_MS - 1000);
+
+			const fetchMock = vi
+				.spyOn(globalThis, "fetch")
+				.mockResolvedValue(
+					new Response(JSON.stringify({ models: [createCodexModel("fresh-startup", true)] }), { status: 200 }),
+				);
+			const { pi } = createPiMock();
+
+			try {
+				await expect(providerExtension(pi)).resolves.toBeUndefined();
+				expect(fetchMock).toHaveBeenCalledTimes(1);
+
+				const callsWithModels = (
+					(pi.registerProvider as ReturnType<typeof vi.fn>).mock.calls as Array<
+						[string, { models?: PiProviderModel[] }]
+					>
+				).filter(([, config]) => config.models && config.models.length > 0);
+				expect(callsWithModels[0]?.[1].models?.[0].id).toBe("fresh-startup");
+
+				const diskCache = loadModelsCache(agentDir, "http://127.0.0.1:8317");
+				expect(diskCache?.models[0].id).toBe("fresh-startup");
+				expect(diskCache?.fastModelIds).toEqual(["fresh-startup"]);
+			} finally {
+				fetchMock.mockRestore();
+			}
+		});
+	});
+
+	it("falls back to a stale cache when the startup fetch fails", async () => {
+		await withTempAgentDir(async (agentDir) => {
+			writeConfig(agentDir, { baseUrl: "http://127.0.0.1:8317", apiKey: "key" });
+			const stale = createMappedModels({ models: [createModel("stale-fallback-startup")] });
+			saveModelsCache(agentDir, stale, Date.now() - MODELS_CACHE_TTL_MS - 1000);
+
+			const fetchMock = vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("network down"));
+			const { pi } = createPiMock();
+
+			try {
+				await expect(providerExtension(pi)).resolves.toBeUndefined();
+				expect(fetchMock).toHaveBeenCalledTimes(1);
+
+				const callsWithModels = (
+					(pi.registerProvider as ReturnType<typeof vi.fn>).mock.calls as Array<
+						[string, { models?: PiProviderModel[] }]
+					>
+				).filter(([, config]) => config.models && config.models.length > 0);
+				expect(callsWithModels[0]?.[1].models?.[0].id).toBe("stale-fallback-startup");
+			} finally {
+				fetchMock.mockRestore();
+			}
+		});
+	});
+});
+
+describe("/cliproxyapi-refresh command", () => {
+	it("is registered by the provider extension", async () => {
+		await withTempAgentDir(async () => {
+			const { pi, commands } = createPiMock();
+			await expect(providerExtension(pi)).resolves.toBeUndefined();
+			const refresh = commands.get("cliproxyapi-refresh");
+			expect(refresh).toBeDefined();
+			expect(refresh?.description).toContain("refresh");
+		});
+	});
+
+	it("refuses arguments and notifies usage", async () => {
+		await withTempAgentDir(async () => {
+			const { pi, commands } = createPiMock();
+			await providerExtension(pi);
+			const refresh = commands.get("cliproxyapi-refresh")!;
+			const notify = vi.fn();
+			const ctx = { ui: { notify } } as unknown as ExtensionCommandContext;
+
+			await refresh.handler("now", ctx);
+			expect(notify).toHaveBeenCalledWith("Usage: /cliproxyapi-refresh", "error");
+		});
+	});
+
+	it("notifies an error when the provider is not configured", async () => {
+		await withTempAgentDir(async () => {
+			const { pi, commands } = createPiMock();
+			await providerExtension(pi);
+			const refresh = commands.get("cliproxyapi-refresh")!;
+			const notify = vi.fn();
+			const ctx = { ui: { notify } } as unknown as ExtensionCommandContext;
+
+			await refresh.handler("", ctx);
+			expect(notify).toHaveBeenCalledWith(expect.stringContaining("not configured"), "error");
+		});
+	});
+
+	it("force-refreshes models, updates the cache, and updates fast model ids", async () => {
+		await withTempAgentDir(async (agentDir) => {
+			writeConfig(agentDir, { baseUrl: "http://127.0.0.1:8317", apiKey: "key" });
+			const stale = createMappedModels({ models: [createModel("stale-refresh")] });
+			saveModelsCache(agentDir, stale, Date.now() - MODELS_CACHE_TTL_MS - 1000);
+
+			const fetchMock = vi
+				.spyOn(globalThis, "fetch")
+				.mockImplementation(() =>
+					Promise.resolve(
+						new Response(JSON.stringify({ models: [createCodexModel("refreshed", true)] }), { status: 200 }),
+					),
+				);
+			const { pi, commands } = createPiMock();
+
+			try {
+				await providerExtension(pi);
+				const refresh = commands.get("cliproxyapi-refresh")!;
+				const notify = vi.fn();
+				const model = { id: "refreshed", provider: "cliproxyapi" } as Model<Api>;
+				const ctx = { model, ui: { notify } } as unknown as ExtensionCommandContext;
+
+				await refresh.handler("", ctx);
+
+				expect(fetchMock).toHaveBeenCalledTimes(2);
+				expect(notify).toHaveBeenCalledWith(expect.stringContaining("Refreshed 1 CLIProxyAPI models"), "info");
+
+				const diskCache = loadModelsCache(agentDir, "http://127.0.0.1:8317");
+				expect(diskCache?.models[0].id).toBe("refreshed");
+				expect(diskCache?.fastModelIds).toEqual(["refreshed"]);
+			} finally {
+				fetchMock.mockRestore();
+			}
+		});
+	});
+
+	it("notifies an error when the remote refresh fails", async () => {
+		await withTempAgentDir(async (agentDir) => {
+			writeConfig(agentDir, { baseUrl: "http://127.0.0.1:8317", apiKey: "key" });
+
+			const fetchMock = vi
+				.spyOn(globalThis, "fetch")
+				.mockResolvedValue(new Response(JSON.stringify({ error: "unauthorized" }), { status: 401 }));
+			const { pi, commands } = createPiMock();
+
+			try {
+				await providerExtension(pi);
+				const refresh = commands.get("cliproxyapi-refresh")!;
+				const notify = vi.fn();
+				const model = { id: "any", provider: "cliproxyapi" } as Model<Api>;
+				const ctx = { model, ui: { notify } } as unknown as ExtensionCommandContext;
+
+				await refresh.handler("", ctx);
+
+				expect(notify).toHaveBeenCalledWith(
+					expect.stringContaining("Failed to refresh CLIProxyAPI models"),
+					"error",
+				);
+			} finally {
+				fetchMock.mockRestore();
+			}
+		});
+	});
+});

--- a/test/pi-compat.test.ts
+++ b/test/pi-compat.test.ts
@@ -71,7 +71,9 @@ describe("pi 0.80.9 compatibility", () => {
 				await expect(providerExtension(pi)).resolves.toBeUndefined();
 				expect(fetchMock).not.toHaveBeenCalled();
 
-				expect([...commands.keys()]).toEqual(["fast"]);
+				expect(commands.size).toBe(2);
+				expect(commands.has("fast")).toBe(true);
+				expect(commands.has("cliproxyapi-refresh")).toBe(true);
 				expect(commands.has("cliproxyapi")).toBe(false);
 				expect(pi.unregisterProvider).toHaveBeenCalledWith("cliproxyapi");
 				expect(pi.registerProvider).toHaveBeenCalledWith(
@@ -123,7 +125,9 @@ describe("pi 0.80.9 compatibility", () => {
 			try {
 				await expect(providerExtension(pi)).resolves.toBeUndefined();
 				expect(fetchMock).toHaveBeenCalled();
-				expect([...commands.keys()]).toEqual(["fast"]);
+				expect(commands.size).toBe(2);
+				expect(commands.has("fast")).toBe(true);
+				expect(commands.has("cliproxyapi-refresh")).toBe(true);
 				expect(commands.has("cliproxyapi")).toBe(false);
 				expect(pi.registerProvider).toHaveBeenCalledWith(
 					"cliproxyapi",


### PR DESCRIPTION
## Background

I run pi against a remote CLIProxyAPI instance, and noticed that every pi startup (and every `resume`) felt sluggish. Profiling showed the culprit: the extension calls `/v1/models` on every single startup and blocks extension init until it returns. Against my remote proxy that's anywhere from ~0.4s to 2.2s per launch — and since `fetch` had no timeout, a hung network could stall startup indefinitely.

Model catalogs just don't change that often, so paying a network round-trip on every launch felt unnecessary.

## Approach

I considered a background-refresh design (register cached models instantly, refresh in the background, re-register on success), but that adds async re-registration timing issues for little gain. Since models change rarely, a plain TTL cache with a manual refresh escape hatch is much simpler and covers the same need:

- **Fresh cache → zero network on startup.** Models register straight from disk.
- **Stale/missing cache → fetch with a 3s timeout**, then rewrite the cache.
- **Fetch failed but stale cache exists → fall back to the stale cache** so the provider keeps working offline (with a warning suggesting a refresh).
- **No cache at all → same behavior as before** (warning logged, no models until the proxy responds).

## What's in the PR

- New cache file `~/.pi/agent/cliproxyapi-models.json` — stores only model metadata, Fast-capable IDs, endpoint URLs and a `fetchedAt` timestamp. **Never stores the API key.** The cache is scoped to the resolved endpoints, so switching `baseUrl` invalidates it automatically.
- 24-hour TTL, 3-second request timeout (`AbortSignal.timeout`) on the models fetch.
- New `/cliproxyapi-refresh` command — forces a remote fetch, rewrites the cache, and re-registers models + Fast support immediately, so you can pick up catalog changes without restarting pi.
- `/login` still always bypasses the cache and validates against the live endpoint, then rewrites the cache.
- README updated with a "Model cache" section documenting all of the above.
- Tests: cache helpers, fresh/stale boundaries, endpoint scoping, timeout wiring, startup-uses-cache-without-fetch, stale fallback, and `/cliproxyapi-refresh` behavior. `npm run check` passes (typecheck + biome + 71/71 vitest).

## Result

With a warm cache, startup and `resume` make zero remote requests — launch latency from this extension is effectively gone. I've been running this build daily against a remote CLIProxyAPI for a while now with no issues.

Happy to adjust the TTL, the command name, or anything else if you'd prefer different defaults.
