### PR TITLE
Add cached models.dev pricing fallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Each invocation switches Fast between on and off and writes the result to `~/.pi
 
 When Fast is effective, pi's model status appends a yellow lowercase `fast`, for example `gpt-5.6-sol • xhigh • fast`. When Fast is off or the selected model is unsupported, the original model status remains unchanged. Supported models do not produce a separate status notification. Running `/fast` with an unsupported model still updates the global preference; enabling it warns that the current model cannot use Fast.
 
-Fast capability is catalog-driven: the plugin considers a CLIProxyAPI model Fast-capable when its `service_tiers` field is a non-empty array. The `additional_speed_tiers` field is ignored. For supported models, Fast injects `service_tier: "priority"`; unsupported models are left unchanged. Fast is independent from pi's reasoning/thinking level.
+Fast capability is catalog-driven: the plugin considers a CLIProxyAPI model Fast-capable when its `service_tiers` field is a non-empty array. The `additional_speed_tiers` field is ignored. For supported models, Fast injects `service_tier: "priority"`; unsupported models are left unchanged. Fast is independent from pi's reasoning/thinking level. When `models.dev` provides `experimental.modes.fast.cost`, the registered model cost switches to those Fast rates as well; the provider is refreshed when `/fast` is toggled. If no Fast price is published, the standard price is retained. The plugin does not guess Fast prices from `-pro`/`-fast` model IDs.
 
 ## Proactive compaction during tool runs
 
@@ -187,7 +187,9 @@ From CPA catalog entry → pi model:
 | `supported_reasoning_levels[].effort` | `thinkingLevelMap` + `reasoning` |
 | `visibility: "hide"` | skipped |
 
-Unsupported pi thinking levels are set to `null` so they are hidden in the UI. Cost is reported as zero (proxy pricing is unknown).
+Unsupported pi thinking levels are set to `null` so they are hidden in the UI. When available, prices are matched against canonical model entries in `models.dev`; `cost.tiers[].tier.size` becomes pi's `inputTokensAbove`, including thresholds such as `272000`. The legacy `context_over_200k` field is used only when no explicit tiers are present. Ambiguous reseller prices are not selected arbitrarily and fall back to zero. These are catalog/list prices, not a guarantee of CPA's own markup or billing.
+
+The raw `models.dev` response is cached for 24 hours at `~/.pi/agent/tmp/models-dev-cache.json`. A fresh cache avoids the network request; an expired cache is refreshed with a three-second timeout, and stale data is retained if refresh fails. If neither the network nor a previous cache is available, pricing safely falls back to zero. A small explicit alias table covers known CLIProxyAPI variants such as `gemini-pro-agent` → `gemini-3.1-pro-preview`; unknown variants are not guessed.
 
 ## Migration from static models.json
 

--- a/extensions/index.ts
+++ b/extensions/index.ts
@@ -139,11 +139,22 @@ async function configureAndRegister(options: {
 	defaultBaseUrl: string;
 	streamSimple: CliproxyCodexStreamSimple;
 	fastMode: FastModeController;
+	onFastModeChange?: () => Promise<void>;
 }): Promise<{ modelCount: number; modelsUrl: string }> {
-	const { pi, agentDir, providerId, providerName, baseUrlInput, apiKey, defaultBaseUrl, streamSimple, fastMode } =
-		options;
+	const {
+		pi,
+		agentDir,
+		providerId,
+		providerName,
+		baseUrlInput,
+		apiKey,
+		defaultBaseUrl,
+		streamSimple,
+		fastMode,
+		onFastModeChange,
+	} = options;
 
-	const loaded = await loadMappedModels(baseUrlInput, apiKey);
+	const loaded = await loadMappedModels(baseUrlInput, apiKey, fastMode.isEnabled(), agentDir);
 
 	try {
 		saveConfigFile(agentDir, {
@@ -167,6 +178,7 @@ async function configureAndRegister(options: {
 		agentDir,
 		streamSimple,
 		fastMode,
+		onFastModeChange,
 	});
 	fastMode.setSupportedModelIds(loaded.fastModelIds);
 
@@ -181,8 +193,9 @@ function createOAuthHandlers(options: {
 	defaultBaseUrl: string;
 	streamSimple: CliproxyCodexStreamSimple;
 	fastMode: FastModeController;
+	onFastModeChange?: () => Promise<void>;
 }) {
-	const { pi, agentDir, providerId, providerName, defaultBaseUrl, streamSimple, fastMode } = options;
+	const { pi, agentDir, providerId, providerName, defaultBaseUrl, streamSimple, fastMode, onFastModeChange } = options;
 
 	return {
 		name: providerName,
@@ -209,6 +222,7 @@ function createOAuthHandlers(options: {
 						defaultBaseUrl,
 						streamSimple,
 						fastMode,
+						onFastModeChange,
 					});
 
 					logInfo(`login ok: registered ${result.modelCount} models from ${result.modelsUrl}`);
@@ -268,10 +282,21 @@ function registerProvider(
 		agentDir: string;
 		streamSimple: CliproxyCodexStreamSimple;
 		fastMode: FastModeController;
+		onFastModeChange?: () => Promise<void>;
 	},
 ): void {
-	const { providerId, providerName, baseUrlInput, apiKey, models, defaultBaseUrl, agentDir, streamSimple, fastMode } =
-		options;
+	const {
+		providerId,
+		providerName,
+		baseUrlInput,
+		apiKey,
+		models,
+		defaultBaseUrl,
+		agentDir,
+		streamSimple,
+		fastMode,
+		onFastModeChange,
+	} = options;
 
 	const endpoints = resolveEndpoints(baseUrlInput);
 	const oauth = createOAuthHandlers({
@@ -282,6 +307,7 @@ function registerProvider(
 		defaultBaseUrl,
 		streamSimple,
 		fastMode,
+		onFastModeChange,
 	});
 
 	// Replace any previous registration so an earlier ambient apiKey does not linger
@@ -308,8 +334,9 @@ export function registerFastCommand(options: {
 	providerId: string;
 	fastMode: FastModeController;
 	onStatusChange?: (ctx: ExtensionContext) => void;
+	onModeChange?: (enabled: boolean, ctx: ExtensionContext) => Promise<void>;
 }): void {
-	const { pi, agentDir, providerId, fastMode, onStatusChange } = options;
+	const { pi, agentDir, providerId, fastMode, onStatusChange, onModeChange } = options;
 
 	pi.registerCommand("fast", {
 		description: "Toggle CLIProxyAPI Fast mode globally.",
@@ -328,6 +355,22 @@ export function registerFastCommand(options: {
 				return;
 			}
 			fastMode.setEnabled(enabled);
+			try {
+				await onModeChange?.(enabled, ctx);
+			} catch (error) {
+				// Keep the registered model metadata and persisted preference in sync
+				// when a live provider refresh fails.
+				fastMode.setEnabled(!enabled);
+				try {
+					saveConfigFile(agentDir, { fast: !enabled });
+				} catch {
+					// The original save already succeeded; report the refresh failure below.
+				}
+				const message = error instanceof Error ? error.message : String(error);
+				ctx.ui.notify(`Failed to refresh model pricing: ${message}`, "warning");
+				onStatusChange?.(ctx);
+				return;
+			}
 			onStatusChange?.(ctx);
 
 			const currentModel = ctx.model;
@@ -376,12 +419,17 @@ export default async function (pi: ExtensionAPI): Promise<void> {
 	const fastFooter = new FastFooterController(identity.providerId, fastMode, () =>
 		proactiveCompaction.getCompactionSettings(),
 	);
+	let refreshModelsForFast: (() => Promise<void>) | undefined;
+	const onFastModeChange = async (): Promise<void> => {
+		await refreshModelsForFast?.();
+	};
 	registerFastCommand({
 		pi,
 		agentDir,
 		providerId: identity.providerId,
 		fastMode,
 		onStatusChange: (ctx) => fastFooter.refresh(ctx),
+		onModeChange: onFastModeChange,
 	});
 	fastFooter.register(pi);
 
@@ -394,10 +442,45 @@ export default async function (pi: ExtensionAPI): Promise<void> {
 		agentDir,
 		streamSimple,
 		fastMode,
+		onFastModeChange: onFastModeChange,
 	});
 	registerTransientNetworkErrorRetry(pi, identity.providerId);
 
 	const connection = resolveConnection(agentDir, identity.providerId);
+	const registerConfiguredProvider = async (
+		currentConnection: NonNullable<ReturnType<typeof resolveConnection>>,
+	): Promise<void> => {
+		const loaded = await loadMappedModels(
+			currentConnection.baseUrlInput,
+			currentConnection.apiKey,
+			fastMode.isEnabled(),
+			agentDir,
+		);
+		fastMode.setSupportedModelIds(loaded.fastModelIds);
+		// Prefer OAuth-only registration when /login already stored credentials so
+		// `/login <provider>` jumps straight into the multi-field flow. Fall back to
+		// ambient apiKey only for config-file / env setups without auth.json.
+		const hasStoredLogin = hasLoginCredential(agentDir, identity.providerId);
+		registerProvider(pi, {
+			providerId: identity.providerId,
+			providerName: identity.providerName,
+			baseUrlInput: currentConnection.baseUrlInput,
+			apiKey: hasStoredLogin ? undefined : currentConnection.apiKey,
+			models: loaded.models,
+			defaultBaseUrl,
+			agentDir,
+			streamSimple,
+			fastMode,
+			onFastModeChange,
+		});
+	};
+	refreshModelsForFast = async (): Promise<void> => {
+		const currentConnection = resolveConnection(agentDir, identity.providerId);
+		if (currentConnection) {
+			await registerConfiguredProvider(currentConnection);
+		}
+	};
+
 	if (!connection) {
 		logInfo(
 			`not configured yet. Use /login ${identity.providerName} or /login ${identity.providerId}. ` +
@@ -408,23 +491,7 @@ export default async function (pi: ExtensionAPI): Promise<void> {
 	}
 
 	try {
-		const loaded = await loadMappedModels(connection.baseUrlInput, connection.apiKey);
-		fastMode.setSupportedModelIds(loaded.fastModelIds);
-		// Prefer OAuth-only registration when /login already stored credentials so
-		// `/login <provider>` jumps straight into the multi-field flow. Fall back to
-		// ambient apiKey only for config-file / env setups without auth.json.
-		const hasStoredLogin = hasLoginCredential(agentDir, identity.providerId);
-		registerProvider(pi, {
-			providerId: identity.providerId,
-			providerName: identity.providerName,
-			baseUrlInput: connection.baseUrlInput,
-			apiKey: hasStoredLogin ? undefined : connection.apiKey,
-			models: loaded.models,
-			defaultBaseUrl,
-			agentDir,
-			streamSimple,
-			fastMode,
-		});
+		await registerConfiguredProvider(connection);
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
 		if (isUnauthorizedModelsError(error)) {

--- a/extensions/index.ts
+++ b/extensions/index.ts
@@ -139,7 +139,7 @@ async function configureAndRegister(options: {
 	defaultBaseUrl: string;
 	streamSimple: CliproxyCodexStreamSimple;
 	fastMode: FastModeController;
-	onFastModeChange?: () => Promise<void>;
+	onFastModeChange?: (enabled: boolean, ctx: ExtensionContext) => Promise<void>;
 }): Promise<{ modelCount: number; modelsUrl: string }> {
 	const {
 		pi,
@@ -193,7 +193,7 @@ function createOAuthHandlers(options: {
 	defaultBaseUrl: string;
 	streamSimple: CliproxyCodexStreamSimple;
 	fastMode: FastModeController;
-	onFastModeChange?: () => Promise<void>;
+	onFastModeChange?: (enabled: boolean, ctx: ExtensionContext) => Promise<void>;
 }) {
 	const { pi, agentDir, providerId, providerName, defaultBaseUrl, streamSimple, fastMode, onFastModeChange } = options;
 
@@ -282,7 +282,7 @@ function registerProvider(
 		agentDir: string;
 		streamSimple: CliproxyCodexStreamSimple;
 		fastMode: FastModeController;
-		onFastModeChange?: () => Promise<void>;
+		onFastModeChange?: (enabled: boolean, ctx: ExtensionContext) => Promise<void>;
 	},
 ): void {
 	const {
@@ -337,6 +337,7 @@ export function registerFastCommand(options: {
 	onModeChange?: (enabled: boolean, ctx: ExtensionContext) => Promise<void>;
 }): void {
 	const { pi, agentDir, providerId, fastMode, onStatusChange, onModeChange } = options;
+	let modeChangeInProgress = false;
 
 	pi.registerCommand("fast", {
 		description: "Toggle CLIProxyAPI Fast mode globally.",
@@ -345,41 +346,62 @@ export function registerFastCommand(options: {
 				ctx.ui.notify("Usage: /fast", "error");
 				return;
 			}
-
-			const enabled = !fastMode.isEnabled();
-			try {
-				saveConfigFile(agentDir, { fast: enabled });
-			} catch (error) {
-				const message = error instanceof Error ? error.message : String(error);
-				ctx.ui.notify(`Failed to save Fast mode: ${message}`, "error");
+			if (modeChangeInProgress) {
+				ctx.ui.notify("Fast mode is already being refreshed. Try again when it finishes.", "warning");
 				return;
 			}
-			fastMode.setEnabled(enabled);
+
+			modeChangeInProgress = true;
 			try {
-				await onModeChange?.(enabled, ctx);
-			} catch (error) {
-				// Keep the registered model metadata and persisted preference in sync
-				// when a live provider refresh fails.
-				fastMode.setEnabled(!enabled);
+				const previousEnabled = fastMode.isEnabled();
+				const enabled = !previousEnabled;
 				try {
-					saveConfigFile(agentDir, { fast: !enabled });
-				} catch {
-					// The original save already succeeded; report the refresh failure below.
+					saveConfigFile(agentDir, { fast: enabled });
+				} catch (error) {
+					const message = error instanceof Error ? error.message : String(error);
+					ctx.ui.notify(`Failed to save Fast mode: ${message}`, "error");
+					return;
 				}
-				const message = error instanceof Error ? error.message : String(error);
-				ctx.ui.notify(`Failed to refresh model pricing: ${message}`, "warning");
+				fastMode.setEnabled(enabled);
+				try {
+					await onModeChange?.(enabled, ctx);
+				} catch (error) {
+					// Restore all three views of the mode after a partial refresh:
+					// in-memory request behavior, persisted preference, and model metadata.
+					fastMode.setEnabled(previousEnabled);
+					const rollbackErrors: string[] = [];
+					try {
+						saveConfigFile(agentDir, { fast: previousEnabled });
+					} catch (rollbackError) {
+						rollbackErrors.push(
+							`config rollback failed: ${rollbackError instanceof Error ? rollbackError.message : String(rollbackError)}`,
+						);
+					}
+					try {
+						await onModeChange?.(previousEnabled, ctx);
+					} catch (rollbackError) {
+						rollbackErrors.push(
+							`pricing rollback failed: ${rollbackError instanceof Error ? rollbackError.message : String(rollbackError)}`,
+						);
+					}
+					const message = error instanceof Error ? error.message : String(error);
+					const rollbackSuffix = rollbackErrors.length > 0 ? ` (${rollbackErrors.join("; ")})` : "";
+					ctx.ui.notify(`Failed to refresh model pricing: ${message}${rollbackSuffix}`, "warning");
+					onStatusChange?.(ctx);
+					return;
+				}
 				onStatusChange?.(ctx);
-				return;
-			}
-			onStatusChange?.(ctx);
 
-			const currentModel = ctx.model;
-			if (!currentModel || currentModel.provider !== providerId || !fastMode.isModelSupported(currentModel.id)) {
-				if (enabled) {
-					ctx.ui.notify("Fast mode is enabled globally, but the current model does not support it.", "warning");
-				} else {
-					ctx.ui.notify("Fast mode is disabled globally.", "info");
+				const currentModel = ctx.model;
+				if (!currentModel || currentModel.provider !== providerId || !fastMode.isModelSupported(currentModel.id)) {
+					if (enabled) {
+						ctx.ui.notify("Fast mode is enabled globally, but the current model does not support it.", "warning");
+					} else {
+						ctx.ui.notify("Fast mode is disabled globally.", "info");
+					}
 				}
+			} finally {
+				modeChangeInProgress = false;
 			}
 		},
 	});
@@ -419,9 +441,9 @@ export default async function (pi: ExtensionAPI): Promise<void> {
 	const fastFooter = new FastFooterController(identity.providerId, fastMode, () =>
 		proactiveCompaction.getCompactionSettings(),
 	);
-	let refreshModelsForFast: (() => Promise<void>) | undefined;
-	const onFastModeChange = async (): Promise<void> => {
-		await refreshModelsForFast?.();
+	let refreshModelsForFast: ((ctx: ExtensionContext) => Promise<void>) | undefined;
+	const onFastModeChange = async (_enabled: boolean, ctx: ExtensionContext): Promise<void> => {
+		await refreshModelsForFast?.(ctx);
 	};
 	registerFastCommand({
 		pi,
@@ -474,10 +496,21 @@ export default async function (pi: ExtensionAPI): Promise<void> {
 			onFastModeChange,
 		});
 	};
-	refreshModelsForFast = async (): Promise<void> => {
+	refreshModelsForFast = async (ctx: ExtensionContext): Promise<void> => {
 		const currentConnection = resolveConnection(agentDir, identity.providerId);
-		if (currentConnection) {
-			await registerConfiguredProvider(currentConnection);
+		if (!currentConnection) return;
+
+		await registerConfiguredProvider(currentConnection);
+		const currentModel = ctx.model;
+		if (!currentModel || currentModel.provider !== identity.providerId) return;
+
+		const refreshedModel = ctx.modelRegistry.find(identity.providerId, currentModel.id);
+		if (!refreshedModel) {
+			throw new Error(`Refreshed model ${identity.providerId}/${currentModel.id} is unavailable`);
+		}
+		if (JSON.stringify(refreshedModel.cost) === JSON.stringify(currentModel.cost)) return;
+		if (!(await pi.setModel(refreshedModel))) {
+			throw new Error(`Unable to activate refreshed model ${identity.providerId}/${currentModel.id}`);
 		}
 	};
 

--- a/extensions/lib.ts
+++ b/extensions/lib.ts
@@ -3,6 +3,7 @@
  */
 
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { readStoredCredential } from "@earendil-works/pi-coding-agent";
 
@@ -20,6 +21,7 @@ export const CLIENT_VERSION = "pi";
 
 /** Keep login credentials effectively permanent; reconfigure via /login. */
 export const CREDENTIAL_TTL_MS = 100 * 365 * 24 * 60 * 60 * 1000;
+export const MODELS_DEV_CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
 
 export const ZERO_COST = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 } as const;
 export const DEFAULT_MAX_TOKENS = 16384;
@@ -79,15 +81,64 @@ export interface CodexClientModelsResponse {
 	data?: CodexClientModel[];
 }
 
+export interface PiProviderCostTier {
+	input: number;
+	output: number;
+	cacheRead: number;
+	cacheWrite: number;
+	/** Apply this rate when total input-side usage is above this threshold. */
+	inputTokensAbove: number;
+}
+
+export interface PiProviderCost {
+	input: number;
+	output: number;
+	cacheRead: number;
+	cacheWrite: number;
+	tiers?: PiProviderCostTier[];
+}
+
 export interface PiProviderModel {
 	id: string;
 	name: string;
 	reasoning: boolean;
 	input: Array<"text" | "image">;
-	cost: { input: number; output: number; cacheRead: number; cacheWrite: number };
+	cost: PiProviderCost;
 	contextWindow: number;
 	maxTokens: number;
 	thinkingLevelMap?: ThinkingLevelMap;
+}
+
+interface ModelsDevCostPayload {
+	input?: unknown;
+	output?: unknown;
+	cache_read?: unknown;
+	cache_write?: unknown;
+	tiers?: unknown;
+	context_over_200k?: unknown;
+}
+
+interface ModelsDevModePayload {
+	cost?: ModelsDevCostPayload;
+}
+
+interface ModelsDevModelPayload {
+	cost?: ModelsDevCostPayload;
+	experimental?: {
+		modes?: Record<string, ModelsDevModePayload | undefined>;
+	};
+}
+
+export interface ModelsDevCostEntry {
+	providerId: string;
+	modelId: string;
+	standard: PiProviderCost;
+	fast?: PiProviderCost;
+}
+
+export interface ModelsDevCostCatalog {
+	exact: Map<string, ModelsDevCostEntry[]>;
+	normalized: Map<string, ModelsDevCostEntry[]>;
 }
 
 export interface OAuthRefreshMeta {
@@ -357,7 +408,11 @@ export function supportsFastServiceTier(model: CodexClientModel): boolean {
 	return Array.isArray(model.service_tiers) && model.service_tiers.length > 0;
 }
 
-export function toPiModel(model: CodexClientModel): PiProviderModel | null {
+export function toPiModel(
+	model: CodexClientModel,
+	costCatalog?: ModelsDevCostCatalog,
+	fastMode = false,
+): PiProviderModel | null {
 	const id = codexModelId(model);
 	if (!id) {
 		return null;
@@ -375,12 +430,16 @@ export function toPiModel(model: CodexClientModel): PiProviderModel | null {
 			: undefined) ??
 		DEFAULT_CONTEXT_WINDOW;
 
+	const cost = costCatalog
+		? matchModelCost(id, costCatalog, fastMode && supportsFastServiceTier(model))
+		: { ...ZERO_COST };
+
 	return {
 		id,
 		name: (model.display_name ?? model.name ?? id).trim() || id,
 		reasoning: hasReasoning,
 		input: buildInputModalities(model),
-		cost: { ...ZERO_COST },
+		cost,
 		contextWindow,
 		maxTokens: DEFAULT_MAX_TOKENS,
 		thinkingLevelMap: buildThinkingLevelMap(efforts),
@@ -441,13 +500,296 @@ export async function fetchCodexModels(modelsUrl: string, apiKey: string): Promi
 	return [];
 }
 
+const MODEL_NAMESPACE_PREFIX =
+	/^(openai|anthropic|google(?:-vertex)?|xai|deepseek|mistral|cohere|zhipuai|moonshotai|minimax|meta)[/:.]/i;
+
+const MODEL_PROVIDER_PREFERENCES: Array<{ pattern: RegExp; providers: string[] }> = [
+	{ pattern: /^(?:gpt-|o[134](?:-|$)|chatgpt-|codex-)/, providers: ["openai", "openai-codex", "opencode"] },
+	{ pattern: /^claude-/, providers: ["anthropic"] },
+	{ pattern: /^(?:gemini-|gemma-)/, providers: ["google", "google-vertex"] },
+	{ pattern: /^grok-/, providers: ["xai"] },
+	{ pattern: /^deepseek-/, providers: ["deepseek"] },
+	{ pattern: /^mistral-/, providers: ["mistral"] },
+	{ pattern: /^command-/, providers: ["cohere"] },
+	{ pattern: /^glm-/, providers: ["zhipuai"] },
+	{ pattern: /^(?:kimi-|moonshot-)/, providers: ["moonshotai"] },
+	{ pattern: /^minimax-/, providers: ["minimax"] },
+	{ pattern: /^llama-/, providers: ["meta"] },
+];
+
+/** Explicit aliases for proxy-specific model ids whose billable base model is known. */
+const MODEL_PRICE_ALIASES: Record<string, string[]> = {
+	"gemini-pro-agent": ["gemini-3.1-pro-preview"],
+	"gemini-3.1-pro-low": ["gemini-3.1-pro-preview"],
+	"gemini-3.6-flash-high": ["gemini-3.6-flash"],
+	"gemini-3-flash-agent": ["gemini-3.5-flash"],
+	"grok-composer-2.5-fast": ["grok-4.3"],
+	"grok-3-mini": ["xai/grok-3-mini"],
+};
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+	return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : undefined;
+}
+
+function finiteNumber(value: unknown): number | undefined {
+	return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function readCostRate(
+	source: Record<string, unknown>,
+	key: "input" | "output" | "cacheRead" | "cacheWrite",
+	fallback: number,
+): number {
+	const rawKey = key === "cacheRead" ? "cache_read" : key === "cacheWrite" ? "cache_write" : key;
+	return finiteNumber(source[key] ?? source[rawKey]) ?? fallback;
+}
+
+function parseModelsDevCost(raw: ModelsDevCostPayload | undefined): PiProviderCost | undefined {
+	if (!raw) return undefined;
+	const source = raw as Record<string, unknown>;
+	const input = finiteNumber(source.input);
+	const output = finiteNumber(source.output);
+	if (input === undefined && output === undefined) return undefined;
+
+	const cost: PiProviderCost = {
+		input: input ?? 0,
+		output: output ?? 0,
+		cacheRead: readCostRate(source, "cacheRead", 0),
+		cacheWrite: readCostRate(source, "cacheWrite", 0),
+	};
+	const tiers = new Map<number, PiProviderCostTier>();
+
+	const addTier = (rawTier: unknown, fallbackThreshold?: number): void => {
+		const tierSource = asRecord(rawTier);
+		if (!tierSource) return;
+		const descriptor = asRecord(tierSource.tier);
+		if (descriptor?.type !== undefined && descriptor.type !== "context") return;
+		const threshold =
+			finiteNumber(tierSource.inputTokensAbove) ?? finiteNumber(descriptor?.size) ?? fallbackThreshold;
+		if (threshold === undefined || threshold <= 0) return;
+		tiers.set(threshold, {
+			input: readCostRate(tierSource, "input", cost.input),
+			output: readCostRate(tierSource, "output", cost.output),
+			cacheRead: readCostRate(tierSource, "cacheRead", cost.cacheRead),
+			cacheWrite: readCostRate(tierSource, "cacheWrite", cost.cacheWrite),
+			inputTokensAbove: threshold,
+		});
+	};
+
+	if (Array.isArray(source.tiers)) {
+		for (const tier of source.tiers) addTier(tier);
+	}
+	if (tiers.size === 0) {
+		// Older models.dev records may expose only this compatibility shortcut.
+		addTier(source.context_over_200k, 200000);
+	}
+	if (tiers.size > 0) {
+		cost.tiers = Array.from(tiers.values()).sort((a, b) => a.inputTokensAbove - b.inputTokensAbove);
+	}
+	return cost;
+}
+
+function cloneCost(cost: PiProviderCost): PiProviderCost {
+	return {
+		input: cost.input,
+		output: cost.output,
+		cacheRead: cost.cacheRead,
+		cacheWrite: cost.cacheWrite,
+		...(cost.tiers ? { tiers: cost.tiers.map((tier) => ({ ...tier })) } : {}),
+	};
+}
+
+function stripModelNamespace(modelId: string): string {
+	return modelId.trim().toLowerCase().replace(MODEL_NAMESPACE_PREFIX, "");
+}
+
+function normalizeModelKey(modelId: string): string {
+	return stripModelNamespace(modelId).replace(/[^a-z0-9]/g, "");
+}
+
+function uniqueStrings(values: string[]): string[] {
+	return Array.from(new Set(values.filter((value) => value.length > 0)));
+}
+
+function preferredProvidersForModel(modelId: string): string[] {
+	const normalizedId = stripModelNamespace(modelId);
+	const namespace = modelId.trim().toLowerCase().match(MODEL_NAMESPACE_PREFIX)?.[1];
+	const familyProviders =
+		MODEL_PROVIDER_PREFERENCES.find(({ pattern }) => pattern.test(normalizedId))?.providers ?? [];
+	return uniqueStrings([namespace ?? "", ...familyProviders]);
+}
+
+function addCatalogEntry(catalog: Map<string, ModelsDevCostEntry[]>, key: string, entry: ModelsDevCostEntry): void {
+	if (!key) return;
+	const entries = catalog.get(key) ?? [];
+	if (!entries.some((candidate) => candidate.providerId === entry.providerId && candidate.modelId === entry.modelId)) {
+		entries.push(entry);
+		catalog.set(key, entries);
+	}
+}
+
+function addModelsDevEntry(catalog: ModelsDevCostCatalog, entry: ModelsDevCostEntry): void {
+	const rawId = entry.modelId.trim().toLowerCase();
+	const strippedId = stripModelNamespace(rawId);
+	for (const key of uniqueStrings([rawId, strippedId])) {
+		addCatalogEntry(catalog.exact, key, entry);
+	}
+	addCatalogEntry(catalog.normalized, normalizeModelKey(rawId), entry);
+}
+
+function sameCostVariants(entries: ModelsDevCostEntry[]): boolean {
+	const fingerprints = new Set(entries.map((entry) => JSON.stringify({ standard: entry.standard, fast: entry.fast })));
+	return fingerprints.size === 1;
+}
+
+function selectModelsDevEntry(entries: ModelsDevCostEntry[], modelId: string): ModelsDevCostEntry | undefined {
+	if (entries.length === 0) return undefined;
+	const preferredProviders = preferredProvidersForModel(modelId);
+	for (const providerId of preferredProviders) {
+		const match = entries.find((entry) => entry.providerId === providerId);
+		if (match) return match;
+	}
+	if (entries.length === 1 || sameCostVariants(entries)) {
+		return [...entries].sort((a, b) => a.providerId.localeCompare(b.providerId))[0];
+	}
+	// Do not silently pick an arbitrary reseller price when the source is ambiguous.
+	return undefined;
+}
+
+function findDirectModelsDevEntry(modelId: string, catalog: ModelsDevCostCatalog): ModelsDevCostEntry | undefined {
+	const rawId = modelId.trim().toLowerCase();
+	const exactKeys = uniqueStrings([rawId, stripModelNamespace(rawId)]);
+	for (const key of exactKeys) {
+		const match = selectModelsDevEntry(catalog.exact.get(key) ?? [], modelId);
+		if (match) return match;
+	}
+	return selectModelsDevEntry(catalog.normalized.get(normalizeModelKey(rawId)) ?? [], modelId);
+}
+
+function findModelsDevEntry(modelId: string, catalog: ModelsDevCostCatalog): ModelsDevCostEntry | undefined {
+	const rawId = modelId.trim().toLowerCase();
+	const lookupIds = uniqueStrings([rawId, ...(MODEL_PRICE_ALIASES[rawId] ?? [])]);
+	for (const lookupId of lookupIds) {
+		const match = findDirectModelsDevEntry(lookupId, catalog);
+		if (match) return match;
+	}
+	return undefined;
+}
+
+interface ModelsDevCacheFile {
+	timestamp: number;
+	providers: Record<string, unknown>;
+}
+
+function getModelsDevCachePath(agentDir?: string): string {
+	if (agentDir?.trim()) {
+		return join(agentDir, "tmp", "models-dev-cache.json");
+	}
+	return join(tmpdir(), "pi-cliproxyapi-models-dev-cache.json");
+}
+
+function readModelsDevCacheFile(cachePath: string): ModelsDevCacheFile | null {
+	try {
+		const raw = readFileSync(cachePath, "utf8");
+		const parsed = asRecord(JSON.parse(raw));
+		if (!parsed || typeof parsed.timestamp !== "number" || !Number.isFinite(parsed.timestamp)) return null;
+		const providers = asRecord(parsed.providers);
+		if (!providers || !isModelsDevProviders(providers)) return null;
+		return { timestamp: parsed.timestamp, providers };
+	} catch {
+		return null;
+	}
+}
+
+function writeModelsDevCacheFile(cachePath: string, providers: Record<string, unknown>): void {
+	try {
+		mkdirSync(dirname(cachePath), { recursive: true });
+		const payload: ModelsDevCacheFile = {
+			timestamp: Date.now(),
+			providers,
+		};
+		writeFileSync(cachePath, JSON.stringify(payload), "utf8");
+	} catch {
+		// Ignore write failure (e.g. read-only filesystem)
+	}
+}
+
+function isModelsDevProviders(value: Record<string, unknown>): boolean {
+	return Object.values(value).some((providerValue) => {
+		const provider = asRecord(providerValue);
+		return asRecord(provider?.models) !== undefined;
+	});
+}
+
+function buildCatalogFromProviders(providers: Record<string, unknown>): ModelsDevCostCatalog {
+	const catalog: ModelsDevCostCatalog = { exact: new Map(), normalized: new Map() };
+	for (const [providerId, providerValue] of Object.entries(providers)) {
+		const provider = asRecord(providerValue);
+		const models = asRecord(provider?.models);
+		if (!models) continue;
+		for (const [modelId, modelValue] of Object.entries(models)) {
+			const model = asRecord(modelValue) as ModelsDevModelPayload | undefined;
+			const standard = parseModelsDevCost(model?.cost);
+			if (!standard) continue;
+			const fast = parseModelsDevCost(model?.experimental?.modes?.fast?.cost);
+			addModelsDevEntry(catalog, { providerId, modelId, standard, fast });
+		}
+	}
+	return catalog;
+}
+
+export async function fetchModelsDevCostMap(agentDir?: string, forceRefresh = false): Promise<ModelsDevCostCatalog> {
+	const cachePath = getModelsDevCachePath(agentDir);
+	const cached = readModelsDevCacheFile(cachePath);
+
+	if (!forceRefresh && cached && Date.now() - cached.timestamp < MODELS_DEV_CACHE_TTL_MS) {
+		return buildCatalogFromProviders(cached.providers);
+	}
+
+	const controller = new AbortController();
+	const timeoutId = setTimeout(() => controller.abort(), 3000);
+	try {
+		const response = await fetch("https://models.dev/api.json", { signal: controller.signal });
+		if (response.ok) {
+			const providers = asRecord(await response.json());
+			if (providers && isModelsDevProviders(providers)) {
+				writeModelsDevCacheFile(cachePath, providers);
+				return buildCatalogFromProviders(providers);
+			}
+		}
+	} catch {
+		// Retain stale cache if network/JSON fails
+	} finally {
+		clearTimeout(timeoutId);
+	}
+
+	if (cached) {
+		return buildCatalogFromProviders(cached.providers);
+	}
+
+	return { exact: new Map(), normalized: new Map() };
+}
+
+export function matchModelCost(modelId: string, costCatalog: ModelsDevCostCatalog, isFastMode = false): PiProviderCost {
+	const entry = findModelsDevEntry(modelId, costCatalog);
+	if (!entry) return { ...ZERO_COST };
+	return cloneCost(isFastMode && entry.fast ? entry.fast : entry.standard);
+}
+
 export async function loadMappedModels(
 	baseUrlInput: string,
 	apiKey: string,
+	fastMode = false,
+	agentDir?: string,
 ): Promise<{ models: PiProviderModel[]; fastModelIds: string[]; inferenceBaseUrl: string; modelsUrl: string }> {
 	const endpoints = resolveEndpoints(baseUrlInput);
-	const remoteModels = await fetchCodexModels(endpoints.modelsUrl, apiKey);
-	const models = remoteModels.map(toPiModel).filter((model): model is PiProviderModel => model !== null);
+	const [remoteModels, costCatalog] = await Promise.all([
+		fetchCodexModels(endpoints.modelsUrl, apiKey),
+		fetchModelsDevCostMap(agentDir),
+	]);
+	const models = remoteModels
+		.map((model) => toPiModel(model, costCatalog, fastMode))
+		.filter((model): model is PiProviderModel => model !== null);
 	const fastModelIds = Array.from(
 		new Set(
 			remoteModels

--- a/test/fast-command.test.ts
+++ b/test/fast-command.test.ts
@@ -2,13 +2,18 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Api, Model } from "@earendil-works/pi-ai";
-import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { FastModeController } from "../extensions/fast.ts";
 import { registerFastCommand } from "../extensions/index.ts";
 import { loadConfigFile, resolveFastDefault, saveConfigFile } from "../extensions/lib.ts";
 
-function createCommandHarness(fastMode: FastModeController, currentModel: Model<Api>, agentDir: string) {
+function createCommandHarness(
+	fastMode: FastModeController,
+	currentModel: Model<Api>,
+	agentDir: string,
+	onModeChange?: (enabled: boolean, ctx: ExtensionContext) => Promise<void>,
+) {
 	let command: Parameters<ExtensionAPI["registerCommand"]>[1] | undefined;
 	const onStatusChange = vi.fn();
 	const notify = vi.fn();
@@ -18,7 +23,7 @@ function createCommandHarness(fastMode: FastModeController, currentModel: Model<
 		}),
 	} as unknown as ExtensionAPI;
 
-	registerFastCommand({ pi, agentDir, providerId: "cliproxyapi", fastMode, onStatusChange });
+	registerFastCommand({ pi, agentDir, providerId: "cliproxyapi", fastMode, onStatusChange, onModeChange });
 
 	const ctx = {
 		model: currentModel,
@@ -136,6 +141,52 @@ describe("/fast command", () => {
 		expect(loadConfigFile(agentDir)).toEqual({ fast: false });
 		expect(harness.onStatusChange).toHaveBeenCalledTimes(2);
 		expect(harness.notify).toHaveBeenLastCalledWith("Fast mode is disabled globally.", "info");
+	});
+
+	it("rejects an overlapping toggle while pricing refresh is in progress", async () => {
+		const agentDir = tempAgentDir();
+		const fastMode = new FastModeController(false);
+		fastMode.setSupportedModelIds([supportedModel.id]);
+		let finishRefresh: (() => void) | undefined;
+		const onModeChange = vi.fn(
+			async () =>
+				await new Promise<void>((resolve) => {
+					finishRefresh = resolve;
+				}),
+		);
+		const harness = createCommandHarness(fastMode, supportedModel, agentDir, onModeChange);
+
+		const firstToggle = harness.command().handler("", harness.ctx);
+		await vi.waitFor(() => expect(onModeChange).toHaveBeenCalledTimes(1));
+		await harness.command().handler("", harness.ctx);
+
+		expect(fastMode.isEnabled()).toBe(true);
+		expect(loadConfigFile(agentDir)).toEqual({ fast: true });
+		expect(onModeChange).toHaveBeenCalledTimes(1);
+		expect(harness.notify).toHaveBeenCalledWith(
+			"Fast mode is already being refreshed. Try again when it finishes.",
+			"warning",
+		);
+
+		finishRefresh?.();
+		await firstToggle;
+	});
+
+	it("restores state, config, and pricing metadata when refresh fails", async () => {
+		const agentDir = tempAgentDir();
+		const fastMode = new FastModeController(false);
+		fastMode.setSupportedModelIds([supportedModel.id]);
+		const onModeChange = vi.fn(async (enabled: boolean) => {
+			if (enabled) throw new Error("refresh failed");
+		});
+		const harness = createCommandHarness(fastMode, supportedModel, agentDir, onModeChange);
+
+		await harness.command().handler("", harness.ctx);
+
+		expect(fastMode.isEnabled()).toBe(false);
+		expect(loadConfigFile(agentDir)).toEqual({ fast: false });
+		expect(onModeChange.mock.calls.map(([enabled]) => enabled)).toEqual([true, false]);
+		expect(harness.notify).toHaveBeenCalledWith("Failed to refresh model pricing: refresh failed", "warning");
 	});
 
 	it("does not change in-memory state when the global config cannot be written", async () => {

--- a/test/fast.test.ts
+++ b/test/fast.test.ts
@@ -1,4 +1,6 @@
-import { readFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { Api, Model, SimpleStreamOptions } from "@earendil-works/pi-ai";
 import { type ExtensionAPI, type ExtensionContext, FooterComponent } from "@earendil-works/pi-coding-agent";
 import { describe, expect, it, vi } from "vitest";
@@ -219,8 +221,9 @@ describe("Fast catalog mapping", () => {
 			),
 		);
 
+		const agentDir = mkdtempSync(join(tmpdir(), "pi-cliproxyapi-fast-test-"));
 		try {
-			const loaded = await loadMappedModels("http://127.0.0.1:8317", "test-key");
+			const loaded = await loadMappedModels("http://127.0.0.1:8317", "test-key", false, agentDir);
 			expect(loaded.fastModelIds).toEqual(["gpt-5.4", "gpt-5.5"]);
 			expect(loaded.models.map((entry) => entry.id)).toEqual([
 				"gpt-5.4",
@@ -234,6 +237,65 @@ describe("Fast catalog mapping", () => {
 			);
 		} finally {
 			fetchMock.mockRestore();
+			rmSync(agentDir, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("Fast pricing mapping", () => {
+	it("uses models.dev standard and experimental Fast prices when loading CPA models", async () => {
+		const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+			if (String(input).startsWith("https://models.dev/")) {
+				return new Response(
+					JSON.stringify({
+						openai: {
+							models: {
+								"gpt-5.6-sol": {
+									cost: {
+										input: 5,
+										output: 30,
+										cache_read: 0.5,
+										cache_write: 6.25,
+									},
+									experimental: {
+										modes: {
+											fast: { cost: { input: 10, output: 60, cache_read: 1, cache_write: 12.5 } },
+										},
+									},
+								},
+							},
+						},
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				);
+			}
+			return new Response(
+				JSON.stringify({
+					models: [{ slug: "gpt-5.6-sol", service_tiers: [{ id: "priority" }] }],
+				}),
+				{ status: 200, headers: { "Content-Type": "application/json" } },
+			);
+		});
+
+		const agentDir = mkdtempSync(join(tmpdir(), "pi-cliproxyapi-fast-test-"));
+		try {
+			const standard = await loadMappedModels("http://127.0.0.1:8317", "test-key", false, agentDir);
+			const fast = await loadMappedModels("http://127.0.0.1:8317", "test-key", true, agentDir);
+			expect(standard.models[0]?.cost).toEqual({
+				input: 5,
+				output: 30,
+				cacheRead: 0.5,
+				cacheWrite: 6.25,
+			});
+			expect(fast.models[0]?.cost).toEqual({
+				input: 10,
+				output: 60,
+				cacheRead: 1,
+				cacheWrite: 12.5,
+			});
+		} finally {
+			fetchMock.mockRestore();
+			rmSync(agentDir, { recursive: true, force: true });
 		}
 	});
 });

--- a/test/lib.test.ts
+++ b/test/lib.test.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	AUTH_FILE_NAME,
 	buildInputModalities,
@@ -16,11 +16,13 @@ import {
 	decodeRefreshMeta,
 	encodeRefreshMeta,
 	extractReasoningEfforts,
+	fetchModelsDevCostMap,
 	firstNonEmpty,
 	isUnauthorizedModelsError,
 	loadAuthConnection,
 	loadConfigFile,
 	ModelsHttpError,
+	matchModelCost,
 	parseBooleanSetting,
 	resolveEndpoints,
 	resolveFastDefault,
@@ -30,6 +32,23 @@ import {
 	toPiModel,
 	ZERO_COST,
 } from "../extensions/lib.ts";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+	while (tempDirs.length > 0) {
+		const dir = tempDirs.pop();
+		if (dir) {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	}
+});
+
+function tempAgentDir(): string {
+	const dir = mkdtempSync(join(tmpdir(), "pi-cliproxyapi-test-"));
+	tempDirs.push(dir);
+	return dir;
+}
 
 describe("firstNonEmpty", () => {
 	it("returns the first non-empty trimmed string", () => {
@@ -166,6 +185,197 @@ describe("model mapping helpers", () => {
 	});
 });
 
+describe("models.dev cost mapping", () => {
+	it("uses canonical provider prices, preserves context tiers, and reads Fast mode costs", async () => {
+		const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					openai: {
+						models: {
+							"gpt-5.6-sol": {
+								cost: {
+									input: 5,
+									output: 30,
+									cache_read: 0.5,
+									cache_write: 6.25,
+									tiers: [
+										{
+											input: 10,
+											output: 45,
+											cache_read: 1,
+											cache_write: 12.5,
+											tier: { type: "context", size: 272000 },
+										},
+									],
+									// This compatibility field must not create a duplicate 200k tier.
+									context_over_200k: { input: 10, output: 45, cache_read: 1, cache_write: 12.5 },
+								},
+								experimental: {
+									modes: {
+										fast: {
+											cost: { input: 10, output: 60, cache_read: 1, cache_write: 12.5 },
+										},
+									},
+								},
+							},
+						},
+					},
+					xpersona: {
+						models: {
+							"gpt-5.6-sol": { cost: { input: 1.5, output: 12, cache_read: 0.15 } },
+						},
+					},
+				}),
+				{ status: 200, headers: { "Content-Type": "application/json" } },
+			),
+		);
+
+		try {
+			const catalog = await fetchModelsDevCostMap(tempAgentDir(), true);
+			expect(matchModelCost("gpt-5.6-sol", catalog)).toEqual({
+				input: 5,
+				output: 30,
+				cacheRead: 0.5,
+				cacheWrite: 6.25,
+				tiers: [
+					{
+						input: 10,
+						output: 45,
+						cacheRead: 1,
+						cacheWrite: 12.5,
+						inputTokensAbove: 272000,
+					},
+				],
+			});
+			expect(matchModelCost("gpt-5.6-sol", catalog, true)).toEqual({
+				input: 10,
+				output: 60,
+				cacheRead: 1,
+				cacheWrite: 12.5,
+			});
+		} finally {
+			fetchMock.mockRestore();
+		}
+	});
+
+	it("resolves confirmed proxy aliases to canonical model prices", async () => {
+		const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					google: {
+						models: {
+							"gemini-3.1-pro-preview": {
+								cost: {
+									input: 2,
+									output: 12,
+									cache_read: 0.2,
+									tiers: [{ input: 4, output: 18, tier: { type: "context", size: 200000 } }],
+								},
+								experimental: { modes: { fast: { cost: { input: 4, output: 24, cache_read: 0.4 } } } },
+							},
+							"gemini-3.5-flash": { cost: { input: 1.5, output: 9, cache_read: 0.15 } },
+							"gemini-3.6-flash": { cost: { input: 1.5, output: 7.5, cache_read: 0.15 } },
+						},
+					},
+					xai: {
+						models: {
+							"grok-4.3": {
+								cost: {
+									input: 1.25,
+									output: 2.5,
+									tiers: [{ input: 2.5, output: 5, tier: { type: "context", size: 200000 } }],
+								},
+							},
+							"xai/grok-3-mini": { cost: { input: 0.3, output: 0.5 } },
+						},
+					},
+				}),
+				{ status: 200, headers: { "Content-Type": "application/json" } },
+			),
+		);
+
+		try {
+			const catalog = await fetchModelsDevCostMap(tempAgentDir(), true);
+			expect(matchModelCost("gemini-pro-agent", catalog)).toMatchObject({ input: 2, output: 12 });
+			expect(matchModelCost("gemini-pro-agent", catalog, true)).toMatchObject({ input: 4, output: 24 });
+			expect(matchModelCost("gemini-3.1-pro-low", catalog).input).toBe(2);
+			expect(matchModelCost("gemini-3.6-flash-high", catalog).output).toBe(7.5);
+			expect(matchModelCost("gemini-3-flash-agent", catalog).output).toBe(9);
+			expect(matchModelCost("grok-composer-2.5-fast", catalog).tiers?.[0]?.inputTokensAbove).toBe(200000);
+			expect(matchModelCost("grok-3-mini", catalog)).toEqual({
+				input: 0.3,
+				output: 0.5,
+				cacheRead: 0,
+				cacheWrite: 0,
+			});
+		} finally {
+			fetchMock.mockRestore();
+		}
+	});
+
+	it("caches models.dev payload to disk and serves subsequent calls from cache", async () => {
+		const tempDir = tempAgentDir();
+		let fetchCount = 0;
+		const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+			fetchCount++;
+			return new Response(
+				JSON.stringify({
+					openai: {
+						models: {
+							"gpt-5.6-sol": { cost: { input: 5, output: 30 } },
+						},
+					},
+				}),
+				{ status: 200 },
+			);
+		});
+
+		try {
+			const catalog1 = await fetchModelsDevCostMap(tempDir);
+			expect(fetchCount).toBe(1);
+			expect(matchModelCost("gpt-5.6-sol", catalog1).input).toBe(5);
+
+			// Second call within TTL should read from cache without hitting network
+			const catalog2 = await fetchModelsDevCostMap(tempDir);
+			expect(fetchCount).toBe(1);
+			expect(matchModelCost("gpt-5.6-sol", catalog2).input).toBe(5);
+		} finally {
+			fetchMock.mockRestore();
+		}
+	});
+
+	it("falls back to stale disk cache when network request fails", async () => {
+		const tempDir = tempAgentDir();
+		let shouldFail = false;
+		const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+			if (shouldFail) {
+				throw new Error("Network offline");
+			}
+			return new Response(
+				JSON.stringify({
+					openai: {
+						models: {
+							"gpt-5.6-sol": { cost: { input: 5, output: 30 } },
+						},
+					},
+				}),
+				{ status: 200 },
+			);
+		});
+
+		try {
+			await fetchModelsDevCostMap(tempDir);
+			shouldFail = true;
+
+			// Force refresh while offline should return stale cache instead of empty catalog
+			const catalog = await fetchModelsDevCostMap(tempDir, true);
+			expect(matchModelCost("gpt-5.6-sol", catalog).input).toBe(5);
+		} finally {
+			fetchMock.mockRestore();
+		}
+	});
+});
+
 describe("ModelsHttpError", () => {
 	it("detects unauthorized status", () => {
 		const unauthorized = new ModelsHttpError(401, "Unauthorized", "nope");
@@ -178,23 +388,6 @@ describe("ModelsHttpError", () => {
 });
 
 describe("config and auth file helpers", () => {
-	const tempDirs: string[] = [];
-
-	afterEach(() => {
-		while (tempDirs.length > 0) {
-			const dir = tempDirs.pop();
-			if (dir) {
-				rmSync(dir, { recursive: true, force: true });
-			}
-		}
-	});
-
-	function tempAgentDir(): string {
-		const dir = mkdtempSync(join(tmpdir(), "pi-cliproxyapi-test-"));
-		tempDirs.push(dir);
-		return dir;
-	}
-
 	it("loads empty config when file is missing", () => {
 		const agentDir = tempAgentDir();
 		expect(loadConfigFile(agentDir)).toEqual({});

--- a/test/pi-compat.test.ts
+++ b/test/pi-compat.test.ts
@@ -1,7 +1,8 @@
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { Api, Model } from "@earendil-works/pi-ai";
+import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { describe, expect, it, vi } from "vitest";
 import providerExtension from "../extensions/index.ts";
 import { AUTH_FILE_NAME } from "../extensions/lib.ts";
@@ -42,17 +43,37 @@ async function withTempAgentDir(run: (agentDir: string) => Promise<void>): Promi
 
 function createPiMock(commands: Map<string, Parameters<ExtensionAPI["registerCommand"]>[1]>) {
 	const handlers = new Map<string, Array<(event: unknown, ctx: ExtensionContext) => unknown>>();
+	const registeredModels = new Map<string, Model<Api>>();
 	const pi = {
 		registerCommand: vi.fn((name: string, options: Parameters<ExtensionAPI["registerCommand"]>[1]) => {
 			commands.set(name, options);
 		}),
-		unregisterProvider: vi.fn(),
-		registerProvider: vi.fn(),
+		unregisterProvider: vi.fn((providerId: string) => {
+			for (const key of registeredModels.keys()) {
+				if (key.startsWith(`${providerId}/`)) registeredModels.delete(key);
+			}
+		}),
+		registerProvider: vi.fn((providerId: string, config: Record<string, unknown>) => {
+			const models = Array.isArray(config.models) ? config.models : [];
+			for (const model of models) {
+				const entry = model as Model<Api>;
+				registeredModels.set(`${providerId}/${entry.id}`, {
+					...entry,
+					provider: providerId,
+					api: config.api as Api,
+					baseUrl: config.baseUrl as string,
+				});
+			}
+		}),
+		setModel: vi.fn(async () => true),
 		on: vi.fn((event: string, handler: (event: unknown, ctx: ExtensionContext) => unknown) => {
 			handlers.set(event, [...(handlers.get(event) ?? []), handler]);
 		}),
 	} as unknown as ExtensionAPI;
-	return { pi, handlers };
+	const modelRegistry = {
+		find: (providerId: string, modelId: string) => registeredModels.get(`${providerId}/${modelId}`),
+	};
+	return { pi, handlers, modelRegistry, registeredModels };
 }
 
 describe("pi 0.82.0 compatibility", () => {
@@ -85,6 +106,81 @@ describe("pi 0.82.0 compatibility", () => {
 				for (const [, config] of (pi.registerProvider as ReturnType<typeof vi.fn>).mock.calls) {
 					expect(config).not.toHaveProperty("apiKey");
 				}
+			} finally {
+				fetchMock.mockRestore();
+			}
+		});
+	});
+
+	it("updates the active session model with Fast pricing after /fast", async () => {
+		await withTempAgentDir(async (agentDir) => {
+			writeFileSync(
+				join(agentDir, "cliproxyapi.json"),
+				JSON.stringify({ baseUrl: "http://127.0.0.1:8317", apiKey: "stored-key" }),
+				"utf8",
+			);
+
+			const commands = new Map<string, Parameters<ExtensionAPI["registerCommand"]>[1]>();
+			const { pi, modelRegistry, registeredModels } = createPiMock(commands);
+			const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+				if (String(input).startsWith("https://models.dev/")) {
+					return new Response(
+						JSON.stringify({
+							openai: {
+								models: {
+									"gpt-5.6-sol": {
+										cost: { input: 5, output: 30, cache_read: 0.5, cache_write: 6.25 },
+										experimental: {
+											modes: {
+												fast: {
+													cost: { input: 10, output: 60, cache_read: 1, cache_write: 12.5 },
+												},
+											},
+										},
+									},
+								},
+							},
+						}),
+						{ status: 200, headers: { "Content-Type": "application/json" } },
+					);
+				}
+				return new Response(
+					JSON.stringify({ models: [{ slug: "gpt-5.6-sol", service_tiers: [{ id: "priority" }] }] }),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				);
+			});
+
+			try {
+				await providerExtension(pi);
+				const currentModel = registeredModels.get("cliproxyapi/gpt-5.6-sol");
+				expect(currentModel?.cost.input).toBe(5);
+				const command = commands.get("fast");
+				if (!command || !currentModel) throw new Error("Fast command or active model is unavailable");
+
+				const ctx = {
+					model: currentModel,
+					modelRegistry,
+					ui: { notify: vi.fn() },
+				} as unknown as ExtensionCommandContext;
+				await command.handler("", ctx);
+
+				expect(pi.setModel).toHaveBeenCalledWith(
+					expect.objectContaining({
+						id: "gpt-5.6-sol",
+						provider: "cliproxyapi",
+						cost: { input: 10, output: 60, cacheRead: 1, cacheWrite: 12.5 },
+					}),
+				);
+
+				const fastModel = (pi.setModel as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as Model<Api>;
+				await command.handler("", { ...ctx, model: fastModel });
+				expect(pi.setModel).toHaveBeenLastCalledWith(
+					expect.objectContaining({
+						id: "gpt-5.6-sol",
+						provider: "cliproxyapi",
+						cost: { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 6.25 },
+					}),
+				);
 			} finally {
 				fetchMock.mockRestore();
 			}


### PR DESCRIPTION
## Summary
- cache models.dev pricing metadata for 24 hours with stale-cache fallback
- parse context pricing tiers and explicit Fast-mode costs
- add confirmed CLIProxyAPI model aliases for canonical pricing
- refresh registered model metadata when Fast mode toggles

## Verification
- `npm run check`
- 63 tests passed