### PR TITLE
fix: reset Codex WebSocket session after compaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Pi provider extension that discovers models from [CLIProxyAPI](https://github.co
 6. Provides `/fast` to toggle OpenAI priority processing for supported models.
 7. Caches the model catalog in `~/.pi/agent/cliproxyapi-models.json`, refreshes it in the background on startup, and provides `/cliproxyapi-refresh` to force a refresh.
 8. In interactive TUI sessions, shows footer elapsed time during runs and a TPS / token usage toast when the agent settles.
+9. After compaction, closes the reused Codex WebSocket for that session so CLIProxyAPI's server-side context resets with the compacted client messages.
 
 ## Install
 
@@ -241,3 +242,4 @@ Disable just this helper via `pi config` if you only want the CLIProxyAPI provid
   - non-200 / network / invalid baseUrl → nothing is persisted; re-enter baseUrl + API key
 - If CPA returns HTTP 200 with zero usable models: login still succeeds; re-run `/login CLIProxyAPI` later after models become available.
 - If the selected model does not provide a non-empty `service_tiers` array: the request is left unchanged; `/fast` still updates the global preference and warns when enabling it.
+- After `/compact`, threshold compaction, or overflow recovery, the provider closes the reused Codex WebSocket for the current session. CLIProxyAPI binds server-side context to the connection, so a reused socket would keep reporting a near-full `cacheRead` and retrigger proactive compaction even though the client context is now small. SSE is unaffected because it bills from the request body.

--- a/extensions/auto-compact.ts
+++ b/extensions/auto-compact.ts
@@ -1,12 +1,29 @@
 import { type Api, type AssistantMessage, createAssistantMessageEventStream, type Model } from "@earendil-works/pi-ai";
 import { type ExtensionAPI, SettingsManager } from "@earendil-works/pi-coding-agent";
-import type { CliproxyCodexStreamSimple } from "./codex-stream.ts";
+import type { CliproxyCodexStreamSimple, CloseCodexWebSocketSessions } from "./codex-stream.ts";
 
 export const PROACTIVE_COMPACTION_ERROR_PREFIX = "context_length_exceeded: proactive compaction threshold reached";
 
 export interface ProactiveCompactionSettings {
 	enabled: boolean;
 	reserveTokens: number;
+}
+
+export type { CloseCodexWebSocketSessions };
+
+/** Session id used to key pi-ai's reused Codex WebSocket. */
+export function resolveCompactionSessionId(source?: {
+	sessionId?: unknown;
+	sessionManager?: { getSessionId?: () => unknown };
+}): string | undefined {
+	const fromManager = source?.sessionManager?.getSessionId?.();
+	if (typeof fromManager === "string" && fromManager.trim()) {
+		return fromManager;
+	}
+	if (typeof source?.sessionId === "string" && source.sessionId.trim()) {
+		return source.sessionId;
+	}
+	return undefined;
 }
 
 export function shouldScheduleProactiveCompaction(
@@ -67,11 +84,19 @@ export function createProactiveCompactionStream(model: Model<Api>, contextTokens
 export class ProactiveCompactionController {
 	private settingsManager: SettingsManager | undefined;
 	private pending: { modelKey: string; contextTokens: number; threshold: number } | undefined;
+	private closeWebSocketSessions: CloseCodexWebSocketSessions | undefined;
 
 	constructor(
 		private readonly agentDir: string,
 		private readonly providerId: string,
-	) {}
+		closeWebSocketSessions?: CloseCodexWebSocketSessions,
+	) {
+		this.closeWebSocketSessions = closeWebSocketSessions;
+	}
+
+	setCloseWebSocketSessions(closeWebSocketSessions: CloseCodexWebSocketSessions): void {
+		this.closeWebSocketSessions = closeWebSocketSessions;
+	}
 
 	register(pi: ExtensionAPI): void {
 		pi.on("session_start", (_event, ctx) => {
@@ -86,8 +111,12 @@ export class ProactiveCompactionController {
 			this.pending = undefined;
 		});
 
-		pi.on("session_compact", () => {
+		pi.on("session_compact", (_event, ctx) => {
 			this.pending = undefined;
+			// CLIProxyAPI binds server-side Codex context to the WebSocket. Compaction
+			// only rewrites the client message list, so reuse would keep cacheRead high
+			// and retrigger proactive compaction on a now-small session.
+			this.resetWebSocketSession(resolveCompactionSessionId(ctx));
 		});
 
 		pi.on("agent_settled", () => {
@@ -137,8 +166,21 @@ export class ProactiveCompactionController {
 			}
 
 			this.pending = undefined;
+			this.resetWebSocketSession(options?.sessionId);
 			return createProactiveCompactionStream(model, pending.contextTokens, pending.threshold);
 		};
+	}
+
+	private resetWebSocketSession(sessionId?: string): void {
+		if (!sessionId || !this.closeWebSocketSessions) {
+			return;
+		}
+		try {
+			this.closeWebSocketSessions(sessionId);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			console.warn(`[pi-cliproxyapi-provider] failed to close Codex WebSocket for session ${sessionId}: ${message}`);
+		}
 	}
 
 	private modelKey(model: Pick<Model<Api>, "provider" | "id">): string {

--- a/extensions/codex-stream.ts
+++ b/extensions/codex-stream.ts
@@ -27,10 +27,13 @@ export type CliproxyCodexStreamSimple = (
 	options?: SimpleStreamOptions,
 ) => AssistantMessageEventStream;
 
+export type CloseCodexWebSocketSessions = (sessionId?: string) => void;
+
 export type CliproxyCodexStreams = {
 	streamSimple: CliproxyCodexStreamSimple;
 	stream: CliproxyCodexStreamSimple;
 	api: typeof CLIPROXYAPI_CODEX_API;
+	closeOpenAICodexWebSocketSessions: CloseCodexWebSocketSessions;
 };
 
 export interface CliproxyCodexStreamOptions {
@@ -252,11 +255,17 @@ export async function loadCliproxyCodexStreams(
 	const mod = (await import(pathToFileURL(outPath).href)) as {
 		streamSimple: CliproxyCodexStreamSimple;
 		stream: CliproxyCodexStreamSimple;
+		closeOpenAICodexWebSocketSessions?: CloseCodexWebSocketSessions;
 	};
 
 	if (typeof mod.streamSimple !== "function" || typeof mod.stream !== "function") {
 		throw new Error("patched openai-codex-responses module missing streamSimple/stream exports");
 	}
+
+	// Must come from the patched module: its WebSocket cache is a separate Map
+	// from the stock @earendil-works/pi-ai openai-codex-responses instance.
+	const closeOpenAICodexWebSocketSessions =
+		typeof mod.closeOpenAICodexWebSocketSessions === "function" ? mod.closeOpenAICodexWebSocketSessions : () => {};
 
 	const streamSimple = wrapStreamSimpleForFast(mod.streamSimple, options.shouldUseFast);
 
@@ -264,5 +273,6 @@ export async function loadCliproxyCodexStreams(
 		api: CLIPROXYAPI_CODEX_API,
 		streamSimple,
 		stream: mod.stream,
+		closeOpenAICodexWebSocketSessions,
 	};
 }

--- a/extensions/index.ts
+++ b/extensions/index.ts
@@ -626,6 +626,7 @@ export default async function (pi: ExtensionAPI): Promise<void> {
 		const streams = await loadCliproxyCodexStreams([identity.providerId, "cliproxyapi"], {
 			shouldUseFast: (model) => model.provider === identity.providerId && fastMode.isEffectiveFor(model.id),
 		});
+		proactiveCompaction.setCloseWebSocketSessions(streams.closeOpenAICodexWebSocketSessions);
 		streamSimple = proactiveCompaction.wrapStreamSimple(streams.streamSimple);
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);

--- a/test/auto-compact.test.ts
+++ b/test/auto-compact.test.ts
@@ -3,10 +3,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { type Api, type AssistantMessage, isContextOverflow, type Model } from "@earendil-works/pi-ai";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	PROACTIVE_COMPACTION_ERROR_PREFIX,
 	ProactiveCompactionController,
+	resolveCompactionSessionId,
 	shouldScheduleProactiveCompaction,
 } from "../extensions/auto-compact.ts";
 import type { CliproxyCodexStreamSimple } from "../extensions/codex-stream.ts";
@@ -97,7 +98,8 @@ describe("proactive compaction controller", () => {
 		const pi = {
 			on: (event: string, handler: (event: any, ctx: ExtensionContext) => unknown) => handlers.set(event, handler),
 		} as unknown as ExtensionAPI;
-		const controller = new ProactiveCompactionController(agentDir, "cliproxyapi");
+		const closeWebSocketSessions = vi.fn();
+		const controller = new ProactiveCompactionController(agentDir, "cliproxyapi", closeWebSocketSessions);
 		controller.register(pi);
 
 		const model = {
@@ -106,9 +108,12 @@ describe("proactive compaction controller", () => {
 			api: "openai-codex-responses",
 			contextWindow: CONTEXT_WINDOW,
 		} as Model<Api>;
+		const sessionId = "session-compact-1";
 		const ctx = {
 			cwd,
 			model,
+			sessionId,
+			sessionManager: { getSessionId: () => sessionId },
 			isProjectTrusted: () => false,
 			getContextUsage: () => ({ tokens: THRESHOLD + 1, contextWindow: CONTEXT_WINDOW, percent: 82.4 }),
 		} as unknown as ExtensionContext;
@@ -117,19 +122,51 @@ describe("proactive compaction controller", () => {
 		const baseResult = {} as ReturnType<CliproxyCodexStreamSimple>;
 		const baseStream: CliproxyCodexStreamSimple = () => baseResult;
 		const wrapped = controller.wrapStreamSimple(baseStream);
-		return { ctx, handlers, model, wrapped, baseResult, settingsPath };
+		return { ctx, handlers, model, wrapped, baseResult, settingsPath, closeWebSocketSessions, sessionId, controller };
 	}
 
 	it("injects one overflow before the next provider request", async () => {
-		const { ctx, handlers, model, wrapped, baseResult } = setup();
+		const { ctx, handlers, model, wrapped, baseResult, closeWebSocketSessions, sessionId } = setup();
 		await handlers.get("turn_end")?.({ message: assistantMessage(THRESHOLD + 1), toolResults: [{}] }, ctx);
 
-		const proactiveStream = wrapped(model, { messages: [] });
+		const proactiveStream = wrapped(model, { messages: [] }, { sessionId });
 		const error = await proactiveStream.result();
 		expect(error.stopReason).toBe("error");
 		expect(error.errorMessage).toBe(`${PROACTIVE_COMPACTION_ERROR_PREFIX} (${THRESHOLD + 1} > ${THRESHOLD})`);
 		expect(isContextOverflow(error, CONTEXT_WINDOW)).toBe(true);
-		expect(wrapped(model, { messages: [] })).toBe(baseResult);
+		expect(closeWebSocketSessions).toHaveBeenCalledWith(sessionId);
+		expect(wrapped(model, { messages: [] }, { sessionId })).toBe(baseResult);
+		expect(closeWebSocketSessions).toHaveBeenCalledTimes(1);
+	});
+
+	it("closes the reused Codex WebSocket after compaction", async () => {
+		const { ctx, handlers, model, wrapped, baseResult, closeWebSocketSessions, sessionId } = setup();
+		await handlers.get("turn_end")?.({ message: assistantMessage(THRESHOLD + 1), toolResults: [{}] }, ctx);
+		handlers.get("session_compact")?.({ reason: "overflow", willRetry: true }, ctx);
+		expect(closeWebSocketSessions).toHaveBeenCalledTimes(1);
+		expect(closeWebSocketSessions).toHaveBeenCalledWith(sessionId);
+		// Compaction replaces the client context; do not inject another overflow
+		// against the still-large server cacheRead from the previous socket.
+		expect(wrapped(model, { messages: [] }, { sessionId })).toBe(baseResult);
+		expect(closeWebSocketSessions).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not close a WebSocket when the session id is missing", () => {
+		const { handlers, closeWebSocketSessions } = setup();
+		handlers.get("session_compact")?.({ reason: "manual" }, {
+			sessionManager: { getSessionId: () => "" },
+		} as unknown as ExtensionContext);
+		expect(closeWebSocketSessions).not.toHaveBeenCalled();
+	});
+
+	it("keeps compaction working if WebSocket close throws", () => {
+		const { ctx, handlers, sessionId, controller } = setup();
+		const closeWebSocketSessions = vi.fn(() => {
+			throw new Error("socket already gone");
+		});
+		controller.setCloseWebSocketSessions(closeWebSocketSessions);
+		expect(() => handlers.get("session_compact")?.({}, ctx)).not.toThrow();
+		expect(closeWebSocketSessions).toHaveBeenCalledWith(sessionId);
 	});
 
 	it("reloads settings before scheduling", async () => {
@@ -149,5 +186,21 @@ describe("proactive compaction controller", () => {
 
 		await handlers.get("turn_end")?.({ message, toolResults: [{}] }, ctx);
 		expect(wrapped(model, { messages: [] })).toBe(baseResult);
+	});
+});
+
+describe("resolveCompactionSessionId", () => {
+	it("prefers sessionManager.getSessionId over a stale sessionId field", () => {
+		expect(
+			resolveCompactionSessionId({
+				sessionId: "stale",
+				sessionManager: { getSessionId: () => "current" },
+			}),
+		).toBe("current");
+	});
+
+	it("falls back to sessionId when sessionManager is unavailable", () => {
+		expect(resolveCompactionSessionId({ sessionId: "fallback" })).toBe("fallback");
+		expect(resolveCompactionSessionId({})).toBeUndefined();
 	});
 });

--- a/test/fast.test.ts
+++ b/test/fast.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
 	applyFastPayloadHook,
 	type CliproxyCodexStreamSimple,
+	loadCliproxyCodexStreams,
 	patchCodexSource,
 	withPriorityServiceTier,
 	wrapStreamSimpleForFast,
@@ -41,6 +42,13 @@ describe("Codex WebSocket transport patch", () => {
 		expect(patched).not.toContain('fallbackTransport: websocketStarted ? undefined : "sse",');
 		expect(patched).not.toContain("websocketSseFallbackSessions.add(sessionId);");
 		expect(patched).not.toMatch(/recordWebSocketSseFallback\([^)]*\);\s*break;/);
+		expect(patched).toContain("export function closeOpenAICodexWebSocketSessions(sessionId)");
+	});
+
+	it("exports closeOpenAICodexWebSocketSessions from the patched module instance", async () => {
+		const streams = await loadCliproxyCodexStreams(["cliproxyapi"]);
+		expect(typeof streams.closeOpenAICodexWebSocketSessions).toBe("function");
+		expect(() => streams.closeOpenAICodexWebSocketSessions("missing-session")).not.toThrow();
 	});
 });
 


### PR DESCRIPTION
## Summary

Fixes #6.

After the first proactive compaction, WebSocket sessions looped:

1. `context_length_exceeded: proactive compaction threshold reached`
2. pi compacted the client messages successfully
3. the next request still reported a near-full `cacheRead`
4. proactive compaction fired again
5. the client session was already small → `Nothing to compact (session too small)`
6. repeat

CLIProxyAPI binds Codex server context to the WebSocket. pi-ai reuses that socket by `sessionId`, and compaction only rewrites the client message list. The reused connection kept serving the pre-compaction context, so `cacheRead` never dropped.

SSE is unaffected because it bills from the request body.

## Change

- Export `closeOpenAICodexWebSocketSessions` from the **patched** Codex module. That module has its own `websocketSessionCache`; calling the stock `@earendil-works/pi-ai` helper would close a different Map.
- On `session_compact`, close the WebSocket for `ctx.sessionManager.getSessionId()` (manual `/compact`, threshold, and overflow recovery).
- Also close it before injecting the proactive overflow error, so a retry does not reuse the bloated server session.
- Closing is best-effort: a missing session id or a thrown closer does not block compaction.

## Test plan

- [x] `npm run check` (typecheck, lint, 100 tests)
- [x] Unit tests cover `session_compact` close, overflow-injection close, missing session id, closer throw, and session-id resolution
- [x] Patched `openai-codex-responses` source still exports `closeOpenAICodexWebSocketSessions`