### PR TITLE
fix(models): derive maxTokens from model metadata

### DIFF
--- a/extensions/lib.ts
+++ b/extensions/lib.ts
@@ -71,6 +71,9 @@ export interface CodexClientModel {
 	description?: string;
 	context_window?: number;
 	max_context_window?: number;
+	max_tokens?: number;
+	max_output_tokens?: number;
+	max_completion_tokens?: number;
 	input_modalities?: string[];
 	supported_reasoning_levels?: CodexReasoningLevel[] | string[];
 	default_service_tier?: string | null;
@@ -486,6 +489,21 @@ export function toPiModel(
 	const cost = costCatalog
 		? matchModelCost(id, costCatalog, fastMode && supportsFastServiceTier(model))
 		: { ...ZERO_COST };
+	const maxTokens =
+		(typeof model.max_tokens === "number" && Number.isFinite(model.max_tokens) && model.max_tokens > 0
+			? model.max_tokens
+			: undefined) ??
+		(typeof model.max_output_tokens === "number" &&
+		Number.isFinite(model.max_output_tokens) &&
+		model.max_output_tokens > 0
+			? model.max_output_tokens
+			: undefined) ??
+		(typeof model.max_completion_tokens === "number" &&
+		Number.isFinite(model.max_completion_tokens) &&
+		model.max_completion_tokens > 0
+			? model.max_completion_tokens
+			: undefined) ??
+		DEFAULT_MAX_TOKENS;
 
 	return {
 		id,
@@ -494,7 +512,7 @@ export function toPiModel(
 		input: buildInputModalities(model),
 		cost,
 		contextWindow,
-		maxTokens: DEFAULT_MAX_TOKENS,
+		maxTokens,
 		thinkingLevelMap: buildThinkingLevelMap(efforts),
 	};
 }

--- a/test/lib.test.ts
+++ b/test/lib.test.ts
@@ -173,6 +173,39 @@ describe("model mapping helpers", () => {
 		});
 	});
 
+	it("maps max_tokens from codex catalog entries", () => {
+		const model = toPiModel({ id: "gpt-5.6-sol", max_tokens: 128000 });
+
+		expect(model?.maxTokens).toBe(128000);
+	});
+
+	it("maps alternative output-token fields in priority order", () => {
+		const fromOutputTokens = toPiModel({
+			id: "claude-sonnet-5",
+			max_output_tokens: 128000,
+		});
+		const fromCompletionTokens = toPiModel({
+			id: "gpt-5-mini",
+			max_completion_tokens: 32768,
+		});
+		const preferred = toPiModel({
+			id: "custom-model",
+			max_tokens: 128000,
+			max_output_tokens: 64000,
+			max_completion_tokens: 32000,
+		});
+
+		expect(fromOutputTokens?.maxTokens).toBe(128000);
+		expect(fromCompletionTokens?.maxTokens).toBe(32768);
+		expect(preferred?.maxTokens).toBe(128000);
+	});
+
+	it("falls back when output-token metadata is not positive and finite", () => {
+		for (const value of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+			expect(toPiModel({ id: "invalid-limit", max_tokens: value })?.maxTokens).toBe(DEFAULT_MAX_TOKENS);
+		}
+	});
+
 	it("skips hide visibility and missing ids", () => {
 		expect(toPiModel({ slug: "x", visibility: "hide" })).toBeNull();
 		expect(toPiModel({ display_name: "no-id" })).toBeNull();


### PR DESCRIPTION
## Summary

- Derive Pi model `maxTokens` from CLIProxyAPI metadata in compatibility order: `max_tokens`, `max_output_tokens`, then `max_completion_tokens`.
- Retain `DEFAULT_MAX_TOKENS` when all fields are absent, non-positive, or non-finite.
- Add regression coverage for alternative catalog field names, precedence, 128K limits, and invalid numeric values.

## Test plan

- `npm run check` (8 test files, 98 tests)

Closes #11
