### PR TITLE
fix(auto-compact): support OMP settings manager APIs

### DIFF
--- a/extensions/auto-compact.ts
+++ b/extensions/auto-compact.ts
@@ -9,6 +9,74 @@ export interface ProactiveCompactionSettings {
 	reserveTokens: number;
 }
 
+const DEFAULT_COMPACTION_ENABLED = true;
+const DEFAULT_COMPACTION_RESERVE_TOKENS = 16384;
+
+interface CompatibleSettingsManager {
+	reload?: () => Promise<void> | void;
+	reloadFromDisk?: () => Promise<void> | void;
+	getCompactionSettings?: () => { enabled?: unknown; reserveTokens?: unknown };
+	get?: (key: string) => unknown;
+}
+
+function isCompatibleSettingsManager(value: unknown): value is CompatibleSettingsManager {
+	return typeof value === "object" && value !== null;
+}
+
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+	return (
+		((typeof value === "object" && value !== null) || typeof value === "function") &&
+		typeof (value as { then?: unknown }).then === "function"
+	);
+}
+
+function normalizeCompactionSettings(enabled: unknown, reserveTokens: unknown): ProactiveCompactionSettings {
+	return {
+		enabled: typeof enabled === "boolean" ? enabled : DEFAULT_COMPACTION_ENABLED,
+		reserveTokens:
+			typeof reserveTokens === "number" && Number.isFinite(reserveTokens) && reserveTokens >= 0
+				? reserveTokens
+				: DEFAULT_COMPACTION_RESERVE_TOKENS,
+	};
+}
+
+function readCompactionSettings(manager: CompatibleSettingsManager): ProactiveCompactionSettings | undefined {
+	if (typeof manager.getCompactionSettings === "function") {
+		try {
+			const settings = manager.getCompactionSettings();
+			return normalizeCompactionSettings(settings?.enabled, settings?.reserveTokens);
+		} catch {
+			// Fall through to OMP's key-based settings API when available.
+		}
+	}
+	if (typeof manager.get === "function") {
+		try {
+			return normalizeCompactionSettings(manager.get("compaction.enabled"), manager.get("compaction.reserveTokens"));
+		} catch {
+			return undefined;
+		}
+	}
+	return undefined;
+}
+
+async function reloadSettings(manager: CompatibleSettingsManager): Promise<void> {
+	if (typeof manager.reload === "function") {
+		try {
+			await manager.reload();
+		} catch {
+			// Keep the last successfully read settings when disk reload fails.
+		}
+		return;
+	}
+	if (typeof manager.reloadFromDisk === "function") {
+		try {
+			await manager.reloadFromDisk();
+		} catch {
+			// Keep the last successfully read settings when disk reload fails.
+		}
+	}
+}
+
 export function shouldScheduleProactiveCompaction(
 	message: AssistantMessage,
 	contextTokens: number,
@@ -65,7 +133,8 @@ export function createProactiveCompactionStream(model: Model<Api>, contextTokens
 }
 
 export class ProactiveCompactionController {
-	private settingsManager: SettingsManager | undefined;
+	private settingsManager: CompatibleSettingsManager | undefined;
+	private cachedCompactionSettings: ProactiveCompactionSettings | undefined;
 	private pending: { modelKey: string; contextTokens: number; threshold: number } | undefined;
 
 	constructor(
@@ -74,15 +143,26 @@ export class ProactiveCompactionController {
 	) {}
 
 	register(pi: ExtensionAPI): void {
-		pi.on("session_start", (_event, ctx) => {
-			this.settingsManager = SettingsManager.create(ctx.cwd, this.agentDir, {
-				projectTrusted: ctx.isProjectTrusted(),
-			});
+		pi.on("session_start", async (_event, ctx) => {
+			this.cachedCompactionSettings = undefined;
+			try {
+				const created: unknown = SettingsManager.create(ctx.cwd, this.agentDir, {
+					projectTrusted: ctx.isProjectTrusted(),
+				});
+				const manager = isPromiseLike(created) ? await created : created;
+				this.settingsManager = isCompatibleSettingsManager(manager) ? manager : undefined;
+				this.cachedCompactionSettings = this.settingsManager
+					? readCompactionSettings(this.settingsManager)
+					: undefined;
+			} catch {
+				this.settingsManager = undefined;
+			}
 			this.pending = undefined;
 		});
 
 		pi.on("session_shutdown", () => {
 			this.settingsManager = undefined;
+			this.cachedCompactionSettings = undefined;
 			this.pending = undefined;
 		});
 
@@ -107,8 +187,15 @@ export class ProactiveCompactionController {
 			if (!settingsManager) {
 				return;
 			}
-			await settingsManager.reload();
-			const settings = settingsManager.getCompactionSettings();
+			await reloadSettings(settingsManager);
+			const refreshedSettings = readCompactionSettings(settingsManager);
+			if (refreshedSettings) {
+				this.cachedCompactionSettings = refreshedSettings;
+			}
+			const settings = refreshedSettings ?? this.cachedCompactionSettings;
+			if (!settings) {
+				return;
+			}
 			const contextTokens = ctx.getContextUsage()?.tokens;
 			if (contextTokens === null || contextTokens === undefined) {
 				return;
@@ -126,7 +213,11 @@ export class ProactiveCompactionController {
 	}
 
 	getCompactionSettings(): ProactiveCompactionSettings | undefined {
-		return this.settingsManager?.getCompactionSettings();
+		const current = this.settingsManager ? readCompactionSettings(this.settingsManager) : undefined;
+		if (current) {
+			this.cachedCompactionSettings = current;
+		}
+		return current ?? this.cachedCompactionSettings;
 	}
 
 	wrapStreamSimple(streamSimple: CliproxyCodexStreamSimple): CliproxyCodexStreamSimple {

--- a/test/auto-compact.test.ts
+++ b/test/auto-compact.test.ts
@@ -2,8 +2,8 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { type Api, type AssistantMessage, isContextOverflow, type Model } from "@earendil-works/pi-ai";
-import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
-import { afterEach, describe, expect, it } from "vitest";
+import { type ExtensionAPI, type ExtensionContext, SettingsManager } from "@earendil-works/pi-coding-agent";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	PROACTIVE_COMPACTION_ERROR_PREFIX,
 	ProactiveCompactionController,
@@ -80,6 +80,7 @@ describe("proactive compaction controller", () => {
 	const tempDirs: string[] = [];
 
 	afterEach(() => {
+		vi.restoreAllMocks();
 		while (tempDirs.length > 0) {
 			const dir = tempDirs.pop();
 			if (dir) rmSync(dir, { recursive: true, force: true });
@@ -148,6 +149,125 @@ describe("proactive compaction controller", () => {
 		const message = { ...assistantMessage(THRESHOLD + 1), provider: "other" };
 
 		await handlers.get("turn_end")?.({ message, toolResults: [{}] }, ctx);
+		expect(wrapped(model, { messages: [] })).toBe(baseResult);
+	});
+
+	it("supports OMP settings managers returned asynchronously", async () => {
+		const manager = {
+			get(key: string) {
+				return key === "compaction.enabled"
+					? true
+					: key === "compaction.reserveTokens"
+						? RESERVE_TOKENS
+						: undefined;
+			},
+			reloadFromDisk: vi.fn(async () => undefined),
+		};
+		vi.spyOn(SettingsManager, "create").mockReturnValue(Promise.resolve(manager) as unknown as SettingsManager);
+
+		const agentDir = mkdtempSync(join(tmpdir(), "pi-cliproxyapi-omp-agent-"));
+		const cwd = mkdtempSync(join(tmpdir(), "pi-cliproxyapi-omp-cwd-"));
+		tempDirs.push(agentDir, cwd);
+		const handlers = new Map<string, (event: any, ctx: ExtensionContext) => unknown>();
+		const pi = {
+			on: (event: string, handler: (event: any, ctx: ExtensionContext) => unknown) => handlers.set(event, handler),
+		} as unknown as ExtensionAPI;
+		const controller = new ProactiveCompactionController(agentDir, "cliproxyapi");
+		controller.register(pi);
+
+		const model = {
+			id: "gpt-5.6-sol",
+			provider: "cliproxyapi",
+			api: "openai-codex-responses",
+			contextWindow: CONTEXT_WINDOW,
+		} as Model<Api>;
+		const ctx = {
+			cwd,
+			model,
+			isProjectTrusted: () => false,
+			getContextUsage: () => ({ tokens: THRESHOLD + 1, contextWindow: CONTEXT_WINDOW, percent: 82.4 }),
+		} as unknown as ExtensionContext;
+		const baseResult = {} as ReturnType<CliproxyCodexStreamSimple>;
+		const baseStream: CliproxyCodexStreamSimple = () => baseResult;
+		const wrapped = controller.wrapStreamSimple(baseStream);
+
+		await handlers.get("session_start")?.({}, ctx);
+		await handlers.get("turn_end")?.({ message: assistantMessage(THRESHOLD + 1), toolResults: [{}] }, ctx);
+
+		expect(manager.reloadFromDisk).toHaveBeenCalledOnce();
+		const proactiveStream = wrapped(model, { messages: [] });
+		const error = await proactiveStream.result();
+		expect(error.stopReason).toBe("error");
+	});
+
+	it("uses the last valid OMP settings when reload and read fail", async () => {
+		let fail = false;
+		const manager = {
+			get(key: string) {
+				if (fail) throw new Error("settings read failed");
+				return key === "compaction.enabled"
+					? true
+					: key === "compaction.reserveTokens"
+						? RESERVE_TOKENS
+						: undefined;
+			},
+			async reloadFromDisk() {
+				if (fail) throw new Error("settings reload failed");
+			},
+		};
+		vi.spyOn(SettingsManager, "create").mockReturnValue(Promise.resolve(manager) as unknown as SettingsManager);
+
+		const agentDir = mkdtempSync(join(tmpdir(), "pi-cliproxyapi-omp-failure-agent-"));
+		const cwd = mkdtempSync(join(tmpdir(), "pi-cliproxyapi-omp-failure-cwd-"));
+		tempDirs.push(agentDir, cwd);
+		const handlers = new Map<string, (event: any, ctx: ExtensionContext) => unknown>();
+		const pi = {
+			on: (event: string, handler: (event: any, ctx: ExtensionContext) => unknown) => handlers.set(event, handler),
+		} as unknown as ExtensionAPI;
+		const controller = new ProactiveCompactionController(agentDir, "cliproxyapi");
+		controller.register(pi);
+
+		const model = {
+			id: "gpt-5.6-sol",
+			provider: "cliproxyapi",
+			api: "openai-codex-responses",
+			contextWindow: CONTEXT_WINDOW,
+		} as Model<Api>;
+		const ctx = {
+			cwd,
+			model,
+			isProjectTrusted: () => false,
+			getContextUsage: () => ({ tokens: THRESHOLD + 1, contextWindow: CONTEXT_WINDOW, percent: 82.4 }),
+		} as unknown as ExtensionContext;
+		const baseStream: CliproxyCodexStreamSimple = () => ({}) as ReturnType<CliproxyCodexStreamSimple>;
+		const wrapped = controller.wrapStreamSimple(baseStream);
+
+		await handlers.get("session_start")?.({}, ctx);
+		expect(controller.getCompactionSettings()).toEqual({
+			enabled: true,
+			reserveTokens: RESERVE_TOKENS,
+		});
+		fail = true;
+
+		await expect(
+			handlers.get("turn_end")?.({ message: assistantMessage(THRESHOLD + 1), toolResults: [{}] }, ctx),
+		).resolves.toBeUndefined();
+		expect(controller.getCompactionSettings()).toEqual({
+			enabled: true,
+			reserveTokens: RESERVE_TOKENS,
+		});
+		expect((await wrapped(model, { messages: [] }).result()).stopReason).toBe("error");
+	});
+
+	it("does not schedule compaction when settings manager creation fails", async () => {
+		vi.spyOn(SettingsManager, "create").mockImplementation(() => {
+			throw new Error("settings unavailable");
+		});
+
+		const { ctx, handlers, model, wrapped, baseResult } = setup();
+		await handlers.get("session_start")?.({}, ctx);
+		await handlers.get("turn_end")?.({ message: assistantMessage(THRESHOLD + 1), toolResults: [{}] }, ctx);
+
 		expect(wrapped(model, { messages: [] })).toBe(baseResult);
 	});
 });


### PR DESCRIPTION
## Summary

- Await synchronous or Promise-returning `SettingsManager.create()` results.
- Support Pi managers through `reload()` and `getCompactionSettings()`.
- Support OMP managers through `reloadFromDisk()` and `get("compaction.enabled" / "compaction.reserveTokens")`.
- Retain the last successfully read compaction settings when a later reload or read fails, preventing settings I/O errors from escaping Pi's `turn_end` handler.
- Preserve the fail-safe behavior of skipping proactive compaction when no usable settings manager or valid settings snapshot is available.
- Add regression coverage for Promise-based OMP managers, transient reload/read failures, and creation failures.

## Test plan

- `npm run check` (8 test files, 98 tests)

## Relationship to PR #10

This PR addresses #13 only (SettingsManager API compatibility). It does not include the WebSocket reset changes from #10. Both branches touch `extensions/auto-compact.ts`; if #10 merges first, this branch may need a mechanical rebase before merging.

Closes #13
