### PR TITLE
fix(transport): respect Pi transport preferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,19 @@ Resolution order for connection settings:
 
 The Fast preference resolves separately as `CLIPROXYAPI_FAST` → `cliproxyapi.json` → `false`.
 
+### Pi transport preference
+
+The plugin does not define or override a separate transport setting. Pi's global `transport` preference is forwarded unchanged to the Codex stream implementation.
+
+| Pi setting | Pi-to-CLIProxyAPI behavior |
+| ------- | --------- |
+| `sse` | Uses the Codex SSE transport. |
+| `websocket` | Prefers WebSocket without cached-context deltas. Pi may fall back to Codex SSE if setup fails before response events begin. |
+| `websocket-cached` | Prefers WebSocket with session continuation and cached-context deltas, with the same pre-stream SSE fallback. |
+| `auto` | Defers selection and fallback behavior to Pi. |
+
+Pi's transport setting controls only the downstream Pi-to-CLIProxyAPI connection. CLIProxyAPI independently selects a credential and chooses that credential's upstream WebSocket or HTTP executor, so a mixed credential pool does not require a model-wide transport downgrade.
+
 ### baseUrl normalization
 
 Preferred form is **host:port only**:

--- a/extensions/codex-stream.ts
+++ b/extensions/codex-stream.ts
@@ -99,67 +99,6 @@ function rewriteRelativeImports(source: string, originalDir: string): string {
 	});
 }
 
-function patchWebSocketOnlyTransport(source: string): string {
-	const sessionIdExpression = String.raw`(?:options\?\.sessionId|cacheSessionId)`;
-	const disabledForSession = new RegExp(
-		String.raw`const websocketDisabledForSession\s*=\s*transport !== "sse" && isWebSocketSseFallbackActive\(${sessionIdExpression}\);`,
-	);
-	const retryVariables = /let retriedWebSocketConnectionLimit\s*=\s*false;/;
-	const connectionLimitRetry =
-		/if \(!aborted && connectionLimitBeforeStart && !retriedWebSocketConnectionLimit\) \{\s*retriedWebSocketConnectionLimit = true;\s*continue;\s*\}/;
-	const websocketFailureHandling = new RegExp(
-		String.raw`if \(aborted \|\| \(isCodexNonTransportError\(error\) && !connectionLimitBeforeStart\)\) \{[\s\S]*?recordWebSocketFailure\((${sessionIdExpression}), error\);[\s\S]*?recordWebSocketSseFallback\(\1\);\s*break;`,
-	);
-	const fallbackSessionRecord = "websocketSseFallbackSessions.add(sessionId);";
-	const fallbackActiveRecord = "stats.websocketFallbackActive = true;";
-
-	for (const fragment of [fallbackSessionRecord, fallbackActiveRecord]) {
-		if (!source.includes(fragment)) {
-			throw new Error("openai-codex-responses source no longer supports the WebSocket-only transport patch");
-		}
-	}
-	for (const pattern of [disabledForSession, retryVariables, connectionLimitRetry, websocketFailureHandling]) {
-		if (!pattern.test(source)) {
-			throw new Error("openai-codex-responses source no longer supports the WebSocket-only transport patch");
-		}
-	}
-
-	return source
-		.replace(disabledForSession, "const websocketDisabledForSession = false;")
-		.replace(
-			retryVariables,
-			`let websocketRetries = 0;
-                const maxWebSocketRetries = Number.isFinite(options?.maxRetries)
-                    ? Math.min(Math.max(0, Math.floor(options.maxRetries)), 5)
-                    : 3;`,
-		)
-		.replace(connectionLimitRetry, "")
-		.replace(
-			websocketFailureHandling,
-			(
-				_match,
-				activeSessionId: string,
-			) => `if (aborted || (isCodexNonTransportError(error) && !connectionLimitBeforeStart)) {
-                            throw error;
-                        }
-                        if (!websocketStarted && websocketRetries < maxWebSocketRetries) {
-                            websocketRetries++;
-                            continue;
-                        }
-                        appendAssistantMessageDiagnostic(output, createAssistantMessageDiagnostic("provider_transport_failure", error, {
-                            configuredTransport: transport,
-                            fallbackTransport: undefined,
-                            eventsEmitted: websocketStarted,
-                            phase: websocketStarted ? "after_message_stream_start" : "before_message_stream_start",
-                            requestBytes: new TextEncoder().encode(bodyJson).byteLength,
-                        }));
-                        recordWebSocketFailure(${activeSessionId}, error);
-                        throw error;`,
-		)
-		.replace(fallbackSessionRecord, "")
-		.replace(fallbackActiveRecord, "stats.websocketFallbackActive = false;");
-}
-
 export function patchCodexSource(source: string, providerIds: string[]): string {
 	let src = source;
 
@@ -192,10 +131,6 @@ export function patchCodexSource(source: string, providerIds: string[]): string 
 
 	// Keep assistant message api metadata aligned with the registered custom api id.
 	src = src.replaceAll(`api: "openai-codex-responses"`, `api: ${JSON.stringify(CLIPROXYAPI_CODEX_API)}`);
-
-	// CLIProxyAPI needs a persistent WebSocket transport. Reconnect before the
-	// response starts and surface a failure rather than silently switching to SSE.
-	src = patchWebSocketOnlyTransport(src);
 
 	// The generated module lives outside the original source map directory.
 	src = src.replace(/^\/\/# sourceMappingURL=.*$/gm, "");

--- a/extensions/index.ts
+++ b/extensions/index.ts
@@ -371,6 +371,7 @@ function registerProvider(
 		baseUrl: endpoints.inferenceBaseUrl,
 		api: CLIPROXYAPI_CODEX_API,
 		streamSimple,
+		headers: { "X-Codex-Beta-Features": "remote_compaction_v2" },
 		// OAuth-only keeps `/login <provider>` on the multi-field account path.
 		// Pass apiKey only for ambient request auth when no /login credential exists
 		// (config file / env). Never pass both for /login flows.

--- a/test/fast.test.ts
+++ b/test/fast.test.ts
@@ -52,26 +52,25 @@ describe("Codex protocol module resolution", () => {
 	});
 });
 
-describe("Codex WebSocket transport patch", () => {
-	it("reconnects WebSocket instead of falling back to SSE", () => {
+describe("Codex transport compatibility patch", () => {
+	it("preserves pi's WebSocket-to-SSE fallback", () => {
 		const source = readFileSync(
 			new URL("../node_modules/@earendil-works/pi-ai/dist/api/openai-codex-responses.js", import.meta.url),
 			"utf8",
 		);
 		const patched = patchCodexSource(source, ["cliproxyapi"]);
 
-		expect(patched).toContain("const websocketDisabledForSession = false;");
-		expect(patched).toContain("let websocketRetries = 0;");
+		expect(patched).toContain(
+			'const websocketDisabledForSession = transport !== "sse" && isWebSocketSseFallbackActive(cacheSessionId);',
+		);
 		expect(patched).toContain("const connectionLimitBeforeStart = !websocketStarted");
 		expect(patched).toContain("isCodexNonTransportError(error) && !connectionLimitBeforeStart");
 		expect(patched).toContain("const previousResponseNotFound = isPreviousResponseNotFoundError(error);");
 		expect(patched).toContain("recordWebSocketFailure(cacheSessionId, error);");
-		expect(patched).toContain("const maxWebSocketRetries = Number.isFinite(options?.maxRetries)");
-		expect(patched).toContain("? Math.min(Math.max(0, Math.floor(options.maxRetries)), 5)");
-		expect(patched).toContain(": 3;");
-		expect(patched).not.toContain('fallbackTransport: websocketStarted ? undefined : "sse",');
-		expect(patched).not.toContain("websocketSseFallbackSessions.add(sessionId);");
-		expect(patched).not.toMatch(/recordWebSocketSseFallback\([^)]*\);\s*break;/);
+		expect(patched).toContain('fallbackTransport: websocketStarted ? undefined : "sse",');
+		expect(patched).toContain("websocketSseFallbackSessions.add(sessionId);");
+		expect(patched).toMatch(/recordWebSocketSseFallback\([^)]*\);\s*break;/);
+		expect(patched).not.toContain("let websocketRetries = 0;");
 	});
 });
 

--- a/test/pi-compat.test.ts
+++ b/test/pi-compat.test.ts
@@ -104,6 +104,9 @@ describe("pi 0.82.0 compatibility", () => {
 					expect.objectContaining({
 						name: "CLIProxyAPI",
 						oauth: expect.any(Object),
+						headers: {
+							"X-Codex-Beta-Features": "remote_compaction_v2",
+						},
 					}),
 				);
 				// OAuth-only registration keeps `/login cliproxyapi` off the API-key selector.


### PR DESCRIPTION
## Summary

- Stop rewriting Pi’s Codex stream into a WebSocket-only retry loop.
- Preserve Pi’s native `auto`, `sse`, `websocket`, and `websocket-cached` behavior, including the pre-stream WebSocket-to-Codex-SSE fallback.
- Send `X-Codex-Beta-Features: remote_compaction_v2` on provider requests.
- Document the boundary between Pi’s downstream transport and CLIProxyAPI’s per-credential upstream executor selection.

## Why

A single CLIProxyAPI model can be backed by a random or round-robin pool containing WebSocket-capable Codex credentials and HTTP-only relay credentials. The provider cannot predict the selected credential, so it should not force or cache a model-wide transport decision. Pi should select the downstream transport, while CLIProxyAPI independently selects the upstream executor for the chosen credential.

This PR does not add cross-protocol replay, model-level sticky downgrade, dual-protocol routing, or OMP runtime changes.

## Test plan

- Regression tests were confirmed red against the upstream implementation and green after applying the existing transport fix.
- `npm run check` (8 test files, 95 tests)
- A real Pi request using only this clean-branch extension returned `OK` through `cliproxyapi/gpt-5.6-sol`.