### PR TITLE
fix(omp): support embedded Bun stream loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Pi provider extension that discovers models from [CLIProxyAPI](https://github.co
 2. Interactive setup collects `baseUrl` + `apiKey` via `/login CLIProxyAPI` or `/login cliproxyapi`.
 3. Fetches `{root}/v1/models?client_version=pi`.
 4. Maps the CLIProxyAPI catalog into pi models, including Fast service-tier capability.
-5. Registers inference against `{root}/backend-api/`.
+5. Registers inference against `{root}/backend-api/` or `{root}/v1/`, depending on the selected protocol.
 6. Provides `/fast` to toggle OpenAI priority processing for supported models.
 7. Caches the model catalog in `~/.pi/agent/cliproxyapi-models.json`, refreshes it in the background on startup, and provides `/cliproxyapi-refresh` to force a refresh.
 8. In interactive TUI sessions, shows footer elapsed time during runs and a TPS / token usage toast when the agent settles.
@@ -99,6 +99,7 @@ Optional fields:
 | `providerName` | `CLIProxyAPI` | Display name in `/login` and UI |
 | `fast` | `false` | Persisted Fast mode preference; only applies to catalog-supported models |
 | `pause` | `false` | Persisted request-pause preference; provider requests wait until it is cleared |
+| `protocol` | auto-detected | Protocol mode (`"openai-codex"` or `"openai-responses"`) |
 
 ### Environment overrides
 
@@ -109,6 +110,7 @@ Optional fields:
 | `CLIPROXYAPI_PROVIDER_ID` | `providerId` |
 | `CLIPROXYAPI_PROVIDER_NAME` | `providerName` |
 | `CLIPROXYAPI_FAST` | `fast` (`true` / `false`, also accepts `1`, `0`, `yes`, `no`, `on`, `off`) |
+| `CLIPROXYAPI_PROTOCOL` | `protocol` (`openai-codex` or `openai-responses`) |
 
 Resolution order for connection settings:
 
@@ -119,18 +121,21 @@ Resolution order for connection settings:
 
 The Fast preference resolves separately as `CLIPROXYAPI_FAST` → `cliproxyapi.json` → `false`.
 
-### baseUrl normalization
+### Protocol modes & baseUrl normalization
 
-Preferred form is **host:port only**:
+The plugin supports two protocols:
 
-| Input | Inference baseUrl | Models URL |
-| ------- | ------------------- | ------------ |
-| `http://127.0.0.1:8317` | `http://127.0.0.1:8317/backend-api/` | `http://127.0.0.1:8317/v1/models?client_version=pi` |
-| `http://127.0.0.1:8317/backend-api` | `http://127.0.0.1:8317/backend-api/` | same models URL |
-| `http://127.0.0.1:8317/v1` | `http://127.0.0.1:8317/backend-api/` | same models URL |
-| `127.0.0.1:8317` | `http://127.0.0.1:8317/backend-api/` | same models URL |
+- **`openai-codex`** (default for `host:port` or `/backend-api`): Uses the patched ChatGPT Codex backend protocol (`/backend-api/codex/responses`) with the existing persistent WebSocket transport.
+- **`openai-responses`** (auto-detected for URLs ending in `/v1`): Uses the standard OpenAI Responses API protocol (`/v1/responses`) over HTTP SSE. Use it for relay endpoints that do not expose the Codex backend protocol.
 
-pi then sends inference traffic to `{inference}/codex/responses`.
+Migration note: previous versions normalized a `/v1` base URL to the Codex backend. `/v1` now auto-selects `openai-responses`; set `"protocol": "openai-codex"` to preserve the previous behavior.
+
+| Input / Mode | Protocol | Inference baseUrl | Models URL |
+| ------- | --------- | ------------------- | ------------ |
+| `http://127.0.0.1:8317` | `openai-codex` | `http://127.0.0.1:8317/backend-api/` | `http://127.0.0.1:8317/v1/models?client_version=pi` |
+| `http://127.0.0.1:8317/backend-api` | `openai-codex` | `http://127.0.0.1:8317/backend-api/` | same models URL |
+| `http://relay.api/v1` | `openai-responses` | `http://relay.api/v1/` | `http://relay.api/v1/models?client_version=pi` |
+| `127.0.0.1:8317` | `openai-codex` | `http://127.0.0.1:8317/backend-api/` | same models URL |
 
 ## Fast mode
 

--- a/extensions/codex-stream.ts
+++ b/extensions/codex-stream.ts
@@ -12,13 +12,14 @@
  * upstream protocol fixes without vendoring 1200+ lines.
  */
 
-import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
-import { createRequire } from "node:module";
+import { createHash, randomUUID } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, realpathSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { createRequire, isBuiltin } from "node:module";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import type { Api, AssistantMessageEventStream, Context, Model, SimpleStreamOptions } from "@earendil-works/pi-ai";
+import { autoDetectProtocol, type ProtocolMode } from "./lib.ts";
 
 export const CLIPROXYAPI_CODEX_API = "cliproxyapi-codex-responses" as const;
 
@@ -76,6 +77,46 @@ export function wrapStreamSimpleForFast(
 	};
 }
 
+export function isBunEmbeddedRuntimeEntry(entryPath: string | undefined): boolean {
+	return entryPath?.replaceAll("\\", "/").includes("/$bunfs/") ?? false;
+}
+
+function cacheContentMatches(path: string, expected: string): boolean {
+	try {
+		return readFileSync(path, "utf8") === expected;
+	} catch {
+		return false;
+	}
+}
+
+export function ensurePatchedModuleCache(
+	targetPath: string,
+	expected: string,
+	options: { rename?: (temporaryPath: string, finalPath: string) => void } = {},
+): void {
+	if (cacheContentMatches(targetPath, expected)) return;
+
+	const temporaryPath = `${targetPath}.${process.pid}.${randomUUID()}.tmp`;
+	let failure: { error: unknown } | undefined;
+	try {
+		writeFileSync(temporaryPath, expected, { encoding: "utf8", flag: "wx" });
+		try {
+			(options.rename ?? renameSync)(temporaryPath, targetPath);
+		} catch (error) {
+			if (!cacheContentMatches(targetPath, expected)) throw error;
+		}
+	} catch (error) {
+		failure = { error };
+	}
+
+	try {
+		unlinkSync(temporaryPath);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== "ENOENT" && !failure) failure = { error };
+	}
+	if (failure) throw failure.error;
+}
+
 const EXTRACT_ACCOUNT_ID_PATCH = `function extractAccountId(token) {
     // CLIProxyAPI accepts plain API keys as well as ChatGPT JWTs.
     // Never throw: missing account id simply means no chatgpt-account-id header.
@@ -92,10 +133,12 @@ const EXTRACT_ACCOUNT_ID_PATCH = `function extractAccountId(token) {
     }
 }`;
 
-function rewriteRelativeImports(source: string, originalDir: string): string {
-	return source.replace(/from\s+"((?:\.\.?\/)[^"]+)"/g, (_full, relPath: string) => {
-		const absolute = pathToFileURL(join(originalDir, relPath)).href;
-		return `from ${JSON.stringify(absolute)}`;
+function rewriteModuleImports(source: string, originalDir: string): string {
+	const require = createRequire(pathToFileURL(join(originalDir, "__pi_ai_resolver__.cjs")));
+	return source.replace(/from\s+(["'])([^"']+)\1/g, (full, _quote: string, specifier: string) => {
+		if (specifier.startsWith("node:") || isBuiltin(specifier)) return full;
+		const resolved = specifier.startsWith(".") ? join(originalDir, specifier) : require.resolve(specifier);
+		return `from ${JSON.stringify(pathToFileURL(resolved).href)}`;
 	});
 }
 
@@ -265,15 +308,13 @@ export async function loadCliproxyCodexStreams(
 ): Promise<CliproxyCodexStreams> {
 	const { path: originalPath, dir: originalDir } = resolveOriginalCodexModulePath();
 	const originalSource = readFileSync(originalPath, "utf8");
-	const patched = rewriteRelativeImports(patchCodexSource(originalSource, providerIds), originalDir);
+	const patched = rewriteModuleImports(patchCodexSource(originalSource, providerIds), originalDir);
 
 	const hash = createHash("sha1").update(patched).digest("hex").slice(0, 16);
 	const cacheDir = join(tmpdir(), "pi-cliproxyapi-provider");
 	mkdirSync(cacheDir, { recursive: true });
 	const outPath = join(cacheDir, `openai-codex-responses-cpa-${hash}.mjs`);
-	if (!existsSync(outPath)) {
-		writeFileSync(outPath, patched, "utf8");
-	}
+	ensurePatchedModuleCache(outPath, patched);
 
 	const mod = (await import(pathToFileURL(outPath).href)) as {
 		streamSimple: CliproxyCodexStreamSimple;
@@ -290,5 +331,128 @@ export async function loadCliproxyCodexStreams(
 		api: CLIPROXYAPI_CODEX_API,
 		streamSimple,
 		stream: mod.stream,
+	};
+}
+
+export function patchResponsesSource(source: string, providerIds: string[]): string {
+	const providersMatch = source.match(/const OPENAI_TOOL_CALL_PROVIDERS = new Set\(\[([^\]]*)\]\);/);
+	if (!providersMatch) {
+		throw new Error("openai-responses source no longer defines OPENAI_TOOL_CALL_PROVIDERS");
+	}
+	const existing = providersMatch[1];
+	const extras = providerIds
+		.filter((id) => id.trim())
+		.map((id) => JSON.stringify(id.trim()))
+		.join(", ");
+	let patched = source.replace(
+		/const OPENAI_TOOL_CALL_PROVIDERS = new Set\(\[([^\]]*)\]\);/,
+		`const OPENAI_TOOL_CALL_PROVIDERS = new Set([${existing}${extras ? `, ${extras}` : ""}]);`,
+	);
+	patched = patched.replace(/^\/\/# sourceMappingURL=.*$/gm, "");
+	return patched;
+}
+
+function resolveOriginalResponsesModulePath(): { path: string; dir: string } {
+	const candidates: string[] = [];
+	const embeddedBun = isBunEmbeddedRuntimeEntry(process.argv[1]);
+
+	if (!embeddedBun) {
+		try {
+			const subpath = import.meta.resolve("@earendil-works/pi-ai/api/openai-responses");
+			candidates.push(fileURLToPath(subpath));
+		} catch {
+			// Ignore and try filesystem candidates.
+		}
+
+		try {
+			const main = fileURLToPath(import.meta.resolve("@earendil-works/pi-ai"));
+			const distDir = dirname(main);
+			candidates.push(join(distDir, "api/openai-responses.js"));
+			candidates.push(join(distDir, "openai-responses.js"));
+		} catch {
+			// Ignore and try the runtime entrypoint.
+		}
+	} else {
+		candidates.push(
+			join(process.cwd(), "node_modules", "@earendil-works", "pi-ai", "dist", "api", "openai-responses.js"),
+		);
+	}
+
+	if (process.argv[1]) {
+		try {
+			const require = createRequire(pathToFileURL(realpathSync(process.argv[1])));
+			for (const nodeModulesDir of require.resolve.paths("@earendil-works/pi-ai") ?? []) {
+				const candidate = join(nodeModulesDir, "@earendil-works", "pi-ai", "dist", "api", "openai-responses.js");
+				if (existsSync(candidate)) candidates.push(candidate);
+			}
+		} catch {
+			// Ignore invalid or unavailable runtime entrypoints.
+		}
+	}
+
+	for (const path of candidates) {
+		if (path && existsSync(path)) return { path, dir: dirname(path) };
+	}
+
+	if (embeddedBun) {
+		throw new Error(
+			"embedded Bun could not locate a physical openai-responses.js; openai-responses protocol is unavailable in this runtime",
+		);
+	}
+	throw new Error(`Cannot resolve openai-responses.js (tried: ${candidates.join(", ") || "none"})`);
+}
+
+export async function loadCliproxyResponsesStreams(
+	providerIds: string[] = ["cliproxyapi"],
+	options: CliproxyCodexStreamOptions = {},
+): Promise<CliproxyCodexStreams> {
+	const { path: originalPath, dir: originalDir } = resolveOriginalResponsesModulePath();
+	const originalSource = readFileSync(originalPath, "utf8");
+	const patched = rewriteModuleImports(patchResponsesSource(originalSource, providerIds), originalDir);
+
+	const hash = createHash("sha1").update(patched).digest("hex").slice(0, 16);
+	const cacheDir = join(tmpdir(), "pi-cliproxyapi-provider");
+	mkdirSync(cacheDir, { recursive: true });
+	const outPath = join(cacheDir, `openai-responses-cpa-${hash}.mjs`);
+	ensurePatchedModuleCache(outPath, patched);
+
+	const mod = (await import(pathToFileURL(outPath).href)) as {
+		streamSimple?: CliproxyCodexStreamSimple;
+		stream?: CliproxyCodexStreamSimple;
+	};
+	if (typeof mod.streamSimple !== "function" || typeof mod.stream !== "function") {
+		throw new Error("patched openai-responses module missing streamSimple/stream exports");
+	}
+
+	return {
+		api: CLIPROXYAPI_CODEX_API,
+		streamSimple: wrapStreamSimpleForFast(mod.streamSimple, options.shouldUseFast),
+		stream: mod.stream,
+	};
+}
+
+export function detectProtocolFromBaseUrl(baseUrl: string | undefined): ProtocolMode {
+	return autoDetectProtocol(baseUrl ?? "");
+}
+
+export function createProtocolStreamDispatcher(
+	codexStreamSimple: CliproxyCodexStreamSimple,
+	responsesStreamSimple?: CliproxyCodexStreamSimple,
+	responsesUnavailableError?: unknown,
+): CliproxyCodexStreamSimple {
+	return (model, context, options) => {
+		if (detectProtocolFromBaseUrl(model.baseUrl) !== "openai-responses") {
+			return codexStreamSimple(model, context, options);
+		}
+		if (!responsesStreamSimple) {
+			const reason =
+				responsesUnavailableError === undefined
+					? ""
+					: `: ${responsesUnavailableError instanceof Error ? responsesUnavailableError.message : String(responsesUnavailableError)}`;
+			throw new Error(`openai-responses protocol is unavailable for this runtime${reason}`, {
+				cause: responsesUnavailableError,
+			});
+		}
+		return responsesStreamSimple(model, context, options);
 	};
 }

--- a/extensions/codex-stream.ts
+++ b/extensions/codex-stream.ts
@@ -12,11 +12,12 @@
  * upstream protocol fixes without vendoring 1200+ lines.
  */
 
+import { Buffer } from "node:buffer";
 import { createHash, randomUUID } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, realpathSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { createRequire, isBuiltin } from "node:module";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import type { Api, AssistantMessageEventStream, Context, Model, SimpleStreamOptions } from "@earendil-works/pi-ai";
 import { autoDetectProtocol, type ProtocolMode } from "./lib.ts";
@@ -77,8 +78,87 @@ export function wrapStreamSimpleForFast(
 	};
 }
 
+export function normalizeContextForPatchedPiAi(context: Context): Context {
+	const systemPrompt = (context as Context & { systemPrompt?: string | string[] }).systemPrompt;
+	if (!Array.isArray(systemPrompt)) return context;
+	return { ...context, systemPrompt: systemPrompt.join("\n\n") };
+}
+
+function wrapPatchedPiAiContext(stream: CliproxyCodexStreamSimple): CliproxyCodexStreamSimple {
+	return (model, context, options) => stream(model, normalizeContextForPatchedPiAi(context), options);
+}
+
 export function isBunEmbeddedRuntimeEntry(entryPath: string | undefined): boolean {
 	return entryPath?.replaceAll("\\", "/").includes("/$bunfs/") ?? false;
+}
+
+interface EmbeddedBunBuildPluginBuilder {
+	onResolve(options: { filter: RegExp }, callback: (args: { path: string }) => { path: string }): void;
+}
+
+interface EmbeddedBunBuildOptions {
+	entrypoints: string[];
+	outdir: string;
+	target: "bun";
+	format: "esm";
+	naming: string;
+	write: false;
+	plugins?: Array<{
+		name: string;
+		setup(build: EmbeddedBunBuildPluginBuilder): void;
+	}>;
+}
+
+interface EmbeddedBunBuildResult {
+	success: boolean;
+	logs?: Array<{ message?: string } | string>;
+	outputs?: Array<{ text(): Promise<string> }>;
+}
+
+type EmbeddedBunBuild = (options: EmbeddedBunBuildOptions) => Promise<EmbeddedBunBuildResult>;
+
+export async function preparePatchedModuleForImport(options: {
+	entryPath: string;
+	outputPath: string;
+	embeddedBun: boolean;
+	build?: EmbeddedBunBuild;
+}): Promise<string> {
+	const { entryPath, outputPath, embeddedBun } = options;
+	if (!embeddedBun) return pathToFileURL(entryPath).href;
+
+	const runtimeBun = (globalThis as unknown as { Bun?: { build?: EmbeddedBunBuild } }).Bun;
+	const build = options.build ?? (runtimeBun?.build ? (buildOptions) => runtimeBun.build!(buildOptions) : undefined);
+	if (!build) {
+		throw new Error("embedded Bun runtime does not expose Bun.build");
+	}
+
+	const result = await build({
+		entrypoints: [entryPath],
+		outdir: dirname(outputPath),
+		target: "bun",
+		format: "esm",
+		naming: basename(outputPath),
+		write: false,
+		plugins: [
+			{
+				name: "physical-file-url",
+				setup(builder) {
+					builder.onResolve({ filter: /^file:/ }, (args) => ({ path: fileURLToPath(args.path) }));
+				},
+			},
+		],
+	});
+	if (!result.success) {
+		const details = result.logs
+			?.map((log) => (typeof log === "string" ? log : log.message))
+			.filter((message): message is string => Boolean(message))
+			.join("; ");
+		throw new Error(`failed to bundle patched module${details ? `: ${details}` : ""}`);
+	}
+	const bundledSource = await result.outputs?.[0]?.text();
+	if (!bundledSource) throw new Error("embedded Bun build returned no output source");
+	// Bun snapshots the temp directory after its first dynamic import, so always load bundles in memory.
+	return `data:text/javascript;base64,${Buffer.from(bundledSource).toString("base64")}`;
 }
 
 function cacheContentMatches(path: string, expected: string): boolean {
@@ -246,92 +326,196 @@ export function patchCodexSource(source: string, providerIds: string[]): string 
 	return src;
 }
 
-export function resolveCodexModuleFromNodeEntry(entryPath: string): string | undefined {
-	try {
-		const require = createRequire(pathToFileURL(realpathSync(entryPath)));
-		for (const nodeModulesDir of require.resolve.paths("@earendil-works/pi-ai") ?? []) {
-			const candidate = join(nodeModulesDir, "@earendil-works", "pi-ai", "dist", "api", "openai-codex-responses.js");
-			if (existsSync(candidate)) {
-				return candidate;
+const PI_AI_PACKAGE_VARIANTS = [
+	join("@earendil-works", "pi-ai"),
+	join("@earendil-works", "pi-coding-agent", "node_modules", "@earendil-works", "pi-ai"),
+	join("@earendil-works", "pi", "node_modules", "@earendil-works", "pi-ai"),
+	join("@mariozechner", "pi-ai"),
+	join("@mariozechner", "pi-coding-agent", "node_modules", "@mariozechner", "pi-ai"),
+	join("@mariozechner", "pi", "node_modules", "@mariozechner", "pi-ai"),
+];
+
+const PI_AI_FILE_VARIANTS = (fileName: string): string[] => [
+	join("dist", "api", fileName),
+	join("api", fileName),
+	join("dist", fileName),
+	fileName,
+];
+
+function collectAncestorModuleRoots(path: string): string[] {
+	const roots: string[] = [];
+	let current = dirname(path);
+	while (true) {
+		roots.push(current, join(current, "node_modules"));
+		const parent = dirname(current);
+		if (parent === current) break;
+		current = parent;
+	}
+	return roots;
+}
+
+function findPiAiModule(searchRoots: Iterable<string>, fileName: string): string | undefined {
+	const relativeFiles = PI_AI_FILE_VARIANTS(fileName);
+	for (const root of searchRoots) {
+		for (const packagePath of PI_AI_PACKAGE_VARIANTS) {
+			for (const relativeFile of relativeFiles) {
+				const candidate = join(root, packagePath, relativeFile);
+				if (existsSync(candidate)) return candidate;
 			}
 		}
+	}
+	return undefined;
+}
+
+export function resolvePiAiModuleFromRuntimeEntry(entryPath: string, fileName: string): string | undefined {
+	try {
+		const real = realpathSync(entryPath);
+		const require = createRequire(pathToFileURL(real));
+		const searchRoots = [
+			...(require.resolve.paths("@earendil-works/pi-ai") ?? []),
+			...collectAncestorModuleRoots(real),
+		];
+		return findPiAiModule(searchRoots, fileName);
 	} catch {
 		// Ignore invalid or unavailable runtime entrypoints.
 	}
 	return undefined;
 }
 
-function resolveOriginalCodexModulePath(): { path: string; dir: string } {
-	// Under pi's extension loader, `@earendil-works/pi-ai` may resolve to dist/compat.js
-	// and package subpath resolve for `/api/*` can fail. Prefer locating the physical
-	// dist file next to the resolved package entry.
-	const candidates: string[] = [];
+export function resolveCodexModuleFromNodeEntry(entryPath: string): string | undefined {
+	return resolvePiAiModuleFromRuntimeEntry(entryPath, "openai-codex-responses.js");
+}
 
-	try {
-		const subpath = import.meta.resolve("@earendil-works/pi-ai/api/openai-codex-responses");
-		candidates.push(fileURLToPath(subpath));
-	} catch {
-		// ignore and try filesystem candidates
+export function resolvePiAiApiSubpath(fileName: string): string {
+	const moduleName = fileName.endsWith(".js") ? fileName.slice(0, -3) : fileName;
+	return `@earendil-works/pi-ai/api/${moduleName}`;
+}
+
+export function resolvePhysicalPiAiModule(fileName: string): { path: string; dir: string } {
+	// Bun's embedded filesystem can block indefinitely in import.meta.resolve.
+	if (!isBunEmbeddedRuntimeEntry(process.argv[1])) {
+		try {
+			const subpath = import.meta.resolve(resolvePiAiApiSubpath(fileName));
+			const subpathFile = fileURLToPath(subpath);
+			if (existsSync(subpathFile)) return { path: subpathFile, dir: dirname(subpathFile) };
+		} catch {
+			// Continue with physical filesystem probes.
+		}
+
+		try {
+			const main = fileURLToPath(import.meta.resolve("@earendil-works/pi-ai"));
+			const distDir = dirname(main);
+			for (const relativePath of [join("api", fileName), fileName]) {
+				const candidate = join(distDir, relativePath);
+				if (existsSync(candidate)) return { path: candidate, dir: dirname(candidate) };
+			}
+		} catch {
+			// Continue with physical filesystem probes.
+		}
 	}
 
-	try {
-		const main = fileURLToPath(import.meta.resolve("@earendil-works/pi-ai"));
-		const distDir = dirname(main);
-		candidates.push(join(distDir, "api/openai-codex-responses.js"));
-		candidates.push(join(distDir, "openai-codex-responses.js"));
-	} catch {
-		// ignore
-	}
-
-	// pi 0.84.3's bundled Node CLI exposes pi-ai as a virtual module to
-	// extensions. Resolve its physical nested dependency from the CLI entry so
-	// the source-patching transport can still read the installed implementation.
+	const searchRoots = new Set<string>();
 	if (process.argv[1]) {
-		const bundledHostModule = resolveCodexModuleFromNodeEntry(process.argv[1]);
-		if (bundledHostModule) {
-			candidates.push(bundledHostModule);
+		try {
+			const candidate = resolvePiAiModuleFromRuntimeEntry(process.argv[1], fileName);
+			if (candidate && existsSync(candidate)) return { path: candidate, dir: dirname(candidate) };
+			const real = realpathSync(process.argv[1]);
+			for (const root of collectAncestorModuleRoots(real)) searchRoots.add(root);
+		} catch {
+			// Ignore virtual or unavailable runtime entrypoints.
 		}
 	}
 
-	for (const path of candidates) {
-		if (path && existsSync(path)) {
-			return { path, dir: dirname(path) };
-		}
+	try {
+		const execDir = dirname(process.execPath);
+		searchRoots.add(execDir);
+		searchRoots.add(join(execDir, "..", "lib", "node_modules"));
+		searchRoots.add(join(execDir, "..", "node_modules"));
+	} catch {
+		// Ignore unavailable executable paths.
 	}
 
-	throw new Error(`Cannot resolve openai-codex-responses.js (tried: ${candidates.join(", ") || "none"})`);
+	try {
+		for (const root of collectAncestorModuleRoots(fileURLToPath(import.meta.url))) searchRoots.add(root);
+	} catch {
+		// Ignore virtual module URLs.
+	}
+
+	try {
+		searchRoots.add(process.cwd());
+		searchRoots.add(join(process.cwd(), "node_modules"));
+	} catch {
+		// Ignore unavailable working directories.
+	}
+
+	const home = process.env.HOME || process.env.USERPROFILE;
+	if (home) {
+		searchRoots.add(join(home, ".pi", "agent", "npm", "node_modules"));
+		searchRoots.add(join(home, ".omp", "plugins", "node_modules"));
+		searchRoots.add(join(home, ".bun", "install", "cache"));
+		searchRoots.add(join(home, ".npm"));
+	}
+
+	searchRoots.add("/usr/local/lib/node_modules");
+	searchRoots.add("/opt/homebrew/lib/node_modules");
+
+	const candidate = findPiAiModule(searchRoots, fileName);
+	if (candidate) return { path: candidate, dir: dirname(candidate) };
+
+	const rootsSample = Array.from(searchRoots).slice(0, 10).join(", ");
+	throw new Error(`Cannot resolve ${fileName} (scanned roots: ${rootsSample || "none"})`);
+}
+
+async function loadPatchedPiAiStreams(options: {
+	fileName: string;
+	providerIds: string[];
+	streamOptions: CliproxyCodexStreamOptions;
+	patchSource: (source: string, providerIds: string[]) => string;
+}): Promise<CliproxyCodexStreams> {
+	const { fileName, providerIds, streamOptions, patchSource } = options;
+	const moduleName = fileName.endsWith(".js") ? fileName.slice(0, -3) : fileName;
+	const { path: originalPath, dir: originalDir } = resolvePhysicalPiAiModule(fileName);
+	const originalSource = readFileSync(originalPath, "utf8");
+	const patched = rewriteModuleImports(patchSource(originalSource, providerIds), originalDir);
+
+	const hash = createHash("sha1").update(patched).digest("hex").slice(0, 16);
+	const cacheDir = join(tmpdir(), "pi-cliproxyapi-provider");
+	mkdirSync(cacheDir, { recursive: true });
+	const outPath = join(cacheDir, `${moduleName}-cpa-${hash}.mjs`);
+	ensurePatchedModuleCache(outPath, patched);
+	const importSpecifier = await preparePatchedModuleForImport({
+		entryPath: outPath,
+		outputPath: join(cacheDir, `${moduleName}-cpa-${hash}-bundled.mjs`),
+		embeddedBun: isBunEmbeddedRuntimeEntry(process.argv[1]),
+	});
+
+	const mod = (await import(importSpecifier)) as {
+		streamSimple?: CliproxyCodexStreamSimple;
+		stream?: CliproxyCodexStreamSimple;
+	};
+	if (typeof mod.streamSimple !== "function" || typeof mod.stream !== "function") {
+		throw new Error(`patched ${moduleName} module missing streamSimple/stream exports`);
+	}
+	const streamSimple = wrapPatchedPiAiContext(mod.streamSimple);
+	const stream = wrapPatchedPiAiContext(mod.stream);
+
+	return {
+		api: CLIPROXYAPI_CODEX_API,
+		streamSimple: wrapStreamSimpleForFast(streamSimple, streamOptions.shouldUseFast),
+		stream,
+	};
 }
 
 export async function loadCliproxyCodexStreams(
 	providerIds: string[] = ["cliproxyapi"],
 	options: CliproxyCodexStreamOptions = {},
 ): Promise<CliproxyCodexStreams> {
-	const { path: originalPath, dir: originalDir } = resolveOriginalCodexModulePath();
-	const originalSource = readFileSync(originalPath, "utf8");
-	const patched = rewriteModuleImports(patchCodexSource(originalSource, providerIds), originalDir);
-
-	const hash = createHash("sha1").update(patched).digest("hex").slice(0, 16);
-	const cacheDir = join(tmpdir(), "pi-cliproxyapi-provider");
-	mkdirSync(cacheDir, { recursive: true });
-	const outPath = join(cacheDir, `openai-codex-responses-cpa-${hash}.mjs`);
-	ensurePatchedModuleCache(outPath, patched);
-
-	const mod = (await import(pathToFileURL(outPath).href)) as {
-		streamSimple: CliproxyCodexStreamSimple;
-		stream: CliproxyCodexStreamSimple;
-	};
-
-	if (typeof mod.streamSimple !== "function" || typeof mod.stream !== "function") {
-		throw new Error("patched openai-codex-responses module missing streamSimple/stream exports");
-	}
-
-	const streamSimple = wrapStreamSimpleForFast(mod.streamSimple, options.shouldUseFast);
-
-	return {
-		api: CLIPROXYAPI_CODEX_API,
-		streamSimple,
-		stream: mod.stream,
-	};
+	return loadPatchedPiAiStreams({
+		fileName: "openai-codex-responses.js",
+		providerIds,
+		streamOptions: options,
+		patchSource: patchCodexSource,
+	});
 }
 
 export function patchResponsesSource(source: string, providerIds: string[]): string {
@@ -352,83 +536,16 @@ export function patchResponsesSource(source: string, providerIds: string[]): str
 	return patched;
 }
 
-function resolveOriginalResponsesModulePath(): { path: string; dir: string } {
-	const candidates: string[] = [];
-	const embeddedBun = isBunEmbeddedRuntimeEntry(process.argv[1]);
-
-	if (!embeddedBun) {
-		try {
-			const subpath = import.meta.resolve("@earendil-works/pi-ai/api/openai-responses");
-			candidates.push(fileURLToPath(subpath));
-		} catch {
-			// Ignore and try filesystem candidates.
-		}
-
-		try {
-			const main = fileURLToPath(import.meta.resolve("@earendil-works/pi-ai"));
-			const distDir = dirname(main);
-			candidates.push(join(distDir, "api/openai-responses.js"));
-			candidates.push(join(distDir, "openai-responses.js"));
-		} catch {
-			// Ignore and try the runtime entrypoint.
-		}
-	} else {
-		candidates.push(
-			join(process.cwd(), "node_modules", "@earendil-works", "pi-ai", "dist", "api", "openai-responses.js"),
-		);
-	}
-
-	if (process.argv[1]) {
-		try {
-			const require = createRequire(pathToFileURL(realpathSync(process.argv[1])));
-			for (const nodeModulesDir of require.resolve.paths("@earendil-works/pi-ai") ?? []) {
-				const candidate = join(nodeModulesDir, "@earendil-works", "pi-ai", "dist", "api", "openai-responses.js");
-				if (existsSync(candidate)) candidates.push(candidate);
-			}
-		} catch {
-			// Ignore invalid or unavailable runtime entrypoints.
-		}
-	}
-
-	for (const path of candidates) {
-		if (path && existsSync(path)) return { path, dir: dirname(path) };
-	}
-
-	if (embeddedBun) {
-		throw new Error(
-			"embedded Bun could not locate a physical openai-responses.js; openai-responses protocol is unavailable in this runtime",
-		);
-	}
-	throw new Error(`Cannot resolve openai-responses.js (tried: ${candidates.join(", ") || "none"})`);
-}
-
 export async function loadCliproxyResponsesStreams(
 	providerIds: string[] = ["cliproxyapi"],
 	options: CliproxyCodexStreamOptions = {},
 ): Promise<CliproxyCodexStreams> {
-	const { path: originalPath, dir: originalDir } = resolveOriginalResponsesModulePath();
-	const originalSource = readFileSync(originalPath, "utf8");
-	const patched = rewriteModuleImports(patchResponsesSource(originalSource, providerIds), originalDir);
-
-	const hash = createHash("sha1").update(patched).digest("hex").slice(0, 16);
-	const cacheDir = join(tmpdir(), "pi-cliproxyapi-provider");
-	mkdirSync(cacheDir, { recursive: true });
-	const outPath = join(cacheDir, `openai-responses-cpa-${hash}.mjs`);
-	ensurePatchedModuleCache(outPath, patched);
-
-	const mod = (await import(pathToFileURL(outPath).href)) as {
-		streamSimple?: CliproxyCodexStreamSimple;
-		stream?: CliproxyCodexStreamSimple;
-	};
-	if (typeof mod.streamSimple !== "function" || typeof mod.stream !== "function") {
-		throw new Error("patched openai-responses module missing streamSimple/stream exports");
-	}
-
-	return {
-		api: CLIPROXYAPI_CODEX_API,
-		streamSimple: wrapStreamSimpleForFast(mod.streamSimple, options.shouldUseFast),
-		stream: mod.stream,
-	};
+	return loadPatchedPiAiStreams({
+		fileName: "openai-responses.js",
+		providerIds,
+		streamOptions: options,
+		patchSource: patchResponsesSource,
+	});
 }
 
 export function detectProtocolFromBaseUrl(baseUrl: string | undefined): ProtocolMode {

--- a/extensions/index.ts
+++ b/extensions/index.ts
@@ -21,10 +21,17 @@
 import type { Api, Model, OAuthCredentials, OAuthLoginCallbacks } from "@earendil-works/pi-ai";
 import { type ExtensionAPI, type ExtensionContext, getAgentDir } from "@earendil-works/pi-coding-agent";
 import { ProactiveCompactionController } from "./auto-compact.ts";
-import { CLIPROXYAPI_CODEX_API, type CliproxyCodexStreamSimple, loadCliproxyCodexStreams } from "./codex-stream.ts";
+import {
+	CLIPROXYAPI_CODEX_API,
+	type CliproxyCodexStreamSimple,
+	createProtocolStreamDispatcher,
+	loadCliproxyCodexStreams,
+	loadCliproxyResponsesStreams,
+} from "./codex-stream.ts";
 import { FastModeController } from "./fast.ts";
 import { FastFooterController } from "./fast-footer.ts";
 import {
+	autoDetectProtocol,
 	CONFIG_FILE_NAME,
 	CREDENTIAL_TTL_MS,
 	DEFAULT_BASE_URL,
@@ -41,6 +48,7 @@ import {
 	resolveIdentity,
 	resolveMappedModels,
 	resolvePauseDefault,
+	resolveProtocol,
 	saveConfigFile,
 } from "./lib.ts";
 import type { PauseController } from "./pause.ts";
@@ -121,6 +129,20 @@ function resolveDefaultBaseUrl(agentDir: string, providerId: string): string {
 	}
 
 	return firstNonEmpty(process.env.CLIPROXYAPI_BASE_URL, fileBaseUrl, authBaseUrl, DEFAULT_BASE_URL)!;
+}
+
+function shouldWarnAboutV1ProtocolMigration(agentDir: string, baseUrlInput: string): boolean {
+	const envProtocol = process.env.CLIPROXYAPI_PROTOCOL?.trim().toLowerCase();
+	if (envProtocol === "openai-codex" || envProtocol === "openai-responses") return false;
+
+	try {
+		const configProtocol = loadConfigFile(agentDir).protocol;
+		if (configProtocol === "openai-codex" || configProtocol === "openai-responses") return false;
+	} catch {
+		// Invalid or unavailable config provides no explicit protocol selection.
+	}
+
+	return autoDetectProtocol(baseUrlInput) === "openai-responses";
 }
 
 async function promptConnection(
@@ -308,7 +330,8 @@ function createOAuthHandlers(options: {
 				return models;
 			}
 			try {
-				const { inferenceBaseUrl } = resolveEndpoints(meta.baseUrl);
+				const protocol = resolveProtocol(agentDir, meta.baseUrl);
+				const { inferenceBaseUrl } = resolveEndpoints(meta.baseUrl, protocol);
 				return models.map((model) =>
 					model.provider === providerId ? { ...model, baseUrl: inferenceBaseUrl } : model,
 				);
@@ -349,7 +372,8 @@ function registerProvider(
 	} = options;
 	const refreshCoordinator = options.refreshCoordinator ?? new ModelRefreshCoordinator();
 
-	const endpoints = resolveEndpoints(baseUrlInput);
+	const protocol = resolveProtocol(agentDir, baseUrlInput);
+	const endpoints = resolveEndpoints(baseUrlInput, protocol);
 	const oauth = createOAuthHandlers({
 		pi,
 		agentDir,
@@ -371,6 +395,7 @@ function registerProvider(
 		baseUrl: endpoints.inferenceBaseUrl,
 		api: CLIPROXYAPI_CODEX_API,
 		streamSimple,
+		...(protocol === "openai-responses" ? { headers: { "X-Codex-Beta-Features": "remote_compaction_v2" } } : {}),
 		// OAuth-only keeps `/login <provider>` on the multi-field account path.
 		// Pass apiKey only for ambient request auth when no /login credential exists
 		// (config file / env). Never pass both for /login flows.
@@ -596,6 +621,11 @@ export default async function (pi: ExtensionAPI): Promise<void> {
 	const agentDir = getAgentDir();
 	const identity = resolveIdentity(agentDir);
 	const defaultBaseUrl = resolveDefaultBaseUrl(agentDir, identity.providerId);
+	if (shouldWarnAboutV1ProtocolMigration(agentDir, defaultBaseUrl)) {
+		logWarn(
+			'Earlier versions treated /v1 as openai-codex. This URL now auto-selects openai-responses; set protocol: "openai-codex" in cliproxyapi.json or CLIPROXYAPI_PROTOCOL=openai-codex to preserve the previous behavior.',
+		);
+	}
 
 	let pauseEnabled = false;
 	try {
@@ -621,17 +651,35 @@ export default async function (pi: ExtensionAPI): Promise<void> {
 	const fastMode = new FastModeController(fastEnabled);
 	const modelRefreshCoordinator = new ModelRefreshCoordinator();
 
-	let streamSimple: CliproxyCodexStreamSimple;
+	let codexStreamSimple: CliproxyCodexStreamSimple | undefined;
+	let responsesStreamSimple: CliproxyCodexStreamSimple | undefined;
+	let responsesStreamLoadError: unknown;
 	try {
-		const streams = await loadCliproxyCodexStreams([identity.providerId, "cliproxyapi"], {
+		const codexStreams = await loadCliproxyCodexStreams([identity.providerId, "cliproxyapi"], {
 			shouldUseFast: (model) => model.provider === identity.providerId && fastMode.isEffectiveFor(model.id),
 		});
-		streamSimple = proactiveCompaction.wrapStreamSimple(streams.streamSimple);
+		codexStreamSimple = proactiveCompaction.wrapStreamSimple(codexStreams.streamSimple);
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
 		logWarn(`failed to load patched codex protocol: ${message}`);
 		return;
 	}
+
+	try {
+		const responsesStreams = await loadCliproxyResponsesStreams([identity.providerId, "cliproxyapi"], {
+			shouldUseFast: (model) => model.provider === identity.providerId && fastMode.isEffectiveFor(model.id),
+		});
+		responsesStreamSimple = proactiveCompaction.wrapStreamSimple(responsesStreams.streamSimple);
+	} catch (error) {
+		responsesStreamLoadError = error;
+		logWarn(`openai-responses protocol unavailable: ${error instanceof Error ? error.message : String(error)}`);
+	}
+
+	const streamSimple = createProtocolStreamDispatcher(
+		codexStreamSimple,
+		responsesStreamSimple,
+		responsesStreamLoadError,
+	);
 
 	const fastFooter = new FastFooterController(identity.providerId, fastMode, () =>
 		proactiveCompaction.getCompactionSettings(),

--- a/extensions/lib.ts
+++ b/extensions/lib.ts
@@ -31,6 +31,8 @@ export const DEFAULT_CONTEXT_WINDOW = 128000;
 
 const PI_THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"] as const;
 
+export type ProtocolMode = "openai-codex" | "openai-responses";
+
 export interface CliproxyConfigFile {
 	baseUrl?: string;
 	apiKey?: string;
@@ -38,6 +40,7 @@ export interface CliproxyConfigFile {
 	providerName?: string;
 	fast?: boolean;
 	pause?: boolean;
+	protocol?: ProtocolMode;
 }
 
 export interface ResolvedIdentity {
@@ -50,6 +53,7 @@ export interface ResolvedConnection {
 	apiKey: string;
 	inferenceBaseUrl: string;
 	modelsUrl: string;
+	protocol: ProtocolMode;
 }
 
 export interface CodexReasoningLevel {
@@ -169,6 +173,38 @@ export function firstNonEmpty(...values: Array<string | undefined | null>): stri
 	return undefined;
 }
 
+/** Auto-detect relay Responses URLs while preserving Codex as the default. */
+export function autoDetectProtocol(baseUrlInput: string): ProtocolMode {
+	try {
+		let raw = baseUrlInput.trim();
+		if (!raw) return "openai-codex";
+		if (!/^https?:\/\//i.test(raw)) raw = `http://${raw}`;
+		const url = new URL(raw);
+		const path = url.pathname.replace(/\/+$/, "");
+		if (path === "/v1" || path.endsWith("/v1")) {
+			return "openai-responses";
+		}
+	} catch {
+		// Malformed URLs retain the existing Codex default.
+	}
+	return "openai-codex";
+}
+
+/** Resolve protocol from env, config, then the URL shape. */
+export function resolveProtocol(agentDir: string, baseUrlInput: string): ProtocolMode {
+	const envProtocol = process.env.CLIPROXYAPI_PROTOCOL?.trim().toLowerCase();
+	if (envProtocol === "openai-responses") return "openai-responses";
+	if (envProtocol === "openai-codex") return "openai-codex";
+	try {
+		const config = loadConfigFile(agentDir);
+		if (config.protocol === "openai-responses") return "openai-responses";
+		if (config.protocol === "openai-codex") return "openai-codex";
+	} catch {
+		// Invalid or missing config falls through to URL detection.
+	}
+	return autoDetectProtocol(baseUrlInput);
+}
+
 /**
  * Normalize user-provided base URL into inference + models endpoints.
  *
@@ -177,7 +213,10 @@ export function firstNonEmpty(...values: Array<string | undefined | null>): stri
  * - /v1 rewritten to /backend-api for inference
  * - models always at {root}/v1/models?client_version=pi
  */
-export function resolveEndpoints(baseUrlInput: string): {
+export function resolveEndpoints(
+	baseUrlInput: string,
+	protocol: ProtocolMode = "openai-codex",
+): {
 	inferenceBaseUrl: string;
 	modelsUrl: string;
 	rootOrigin: string;
@@ -192,6 +231,23 @@ export function resolveEndpoints(baseUrlInput: string): {
 
 	const url = new URL(raw);
 	let path = url.pathname.replace(/\/+$/, "");
+
+	if (protocol === "openai-responses") {
+		let v1path: string;
+		if (path === "/v1" || path.endsWith("/v1")) {
+			v1path = path;
+		} else if (path === "" || path === "/" || path === "/backend-api") {
+			v1path = "/v1";
+		} else if (path.endsWith("/backend-api")) {
+			v1path = `${path.slice(0, -"/backend-api".length)}/v1`;
+		} else {
+			v1path = `${path}/v1`;
+		}
+		const inferenceBaseUrl = `${url.origin}${v1path}/`;
+		const modelsPath = `${v1path}/models`.replace(/\/{2,}/g, "/");
+		const modelsUrl = `${url.origin}${modelsPath}?client_version=${encodeURIComponent(CLIENT_VERSION)}`;
+		return { inferenceBaseUrl, modelsUrl, rootOrigin: url.origin };
+	}
 
 	if (path === "/v1") {
 		path = "/backend-api";
@@ -269,7 +325,8 @@ export function loadModelsCache(agentDir: string, baseUrlInput: string): ModelsC
 	const cachePath = join(agentDir, MODELS_CACHE_FILE_NAME);
 	try {
 		const parsed = JSON.parse(readFileSync(cachePath, "utf8")) as Partial<ModelsCacheFile>;
-		const endpoints = resolveEndpoints(baseUrlInput);
+		const protocol = resolveProtocol(agentDir, baseUrlInput);
+		const endpoints = resolveEndpoints(baseUrlInput, protocol);
 		if (
 			typeof parsed.fetchedAt !== "number" ||
 			parsed.modelsUrl !== endpoints.modelsUrl ||
@@ -396,12 +453,14 @@ export function resolveConnection(agentDir: string, providerId: string): Resolve
 		return null;
 	}
 
-	const endpoints = resolveEndpoints(baseUrlInput);
+	const protocol = resolveProtocol(agentDir, baseUrlInput);
+	const endpoints = resolveEndpoints(baseUrlInput, protocol);
 	return {
 		baseUrlInput,
 		apiKey,
 		inferenceBaseUrl: endpoints.inferenceBaseUrl,
 		modelsUrl: endpoints.modelsUrl,
+		protocol,
 	};
 }
 
@@ -857,7 +916,8 @@ export async function loadMappedModels(
 	const pricingEnabled = typeof timeoutOrFastMode === "boolean";
 	const effectiveFastMode = typeof timeoutOrFastMode === "boolean" ? timeoutOrFastMode : false;
 	const timeoutMs = typeof timeoutOrFastMode === "number" ? timeoutOrFastMode : MODELS_REQUEST_TIMEOUT_MS;
-	const endpoints = resolveEndpoints(baseUrlInput);
+	const protocol = agentDir ? resolveProtocol(agentDir, baseUrlInput) : autoDetectProtocol(baseUrlInput);
+	const endpoints = resolveEndpoints(baseUrlInput, protocol);
 	const [remoteModels, costCatalog] = await Promise.all([
 		fetchCodexModels(endpoints.modelsUrl, apiKey, timeoutMs, signal),
 		pricingEnabled ? fetchModelsDevCostMap(agentDir, false, signal) : Promise.resolve(undefined),

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -162,7 +162,23 @@ describe("models cache helpers", () => {
 
 		expect(loadModelsCache(agentDir, "127.0.0.1:8317")).toEqual({ ...loaded, fetchedAt });
 		expect(loadModelsCache(agentDir, "http://127.0.0.1:8317/")).toEqual({ ...loaded, fetchedAt });
-		expect(loadModelsCache(agentDir, "http://127.0.0.1:8317/v1")).toEqual({ ...loaded, fetchedAt });
+		expect(loadModelsCache(agentDir, "http://127.0.0.1:8317/backend-api")).toEqual({ ...loaded, fetchedAt });
+	});
+
+	it("matches cache across equivalent openai-responses baseUrl forms", () => {
+		const agentDir = tempAgentDir();
+		const endpoints = resolveEndpoints("http://relay.api/v1", "openai-responses");
+		const loaded: MappedModels = {
+			models: [createModel("m1")],
+			fastModelIds: [],
+			inferenceBaseUrl: endpoints.inferenceBaseUrl,
+			modelsUrl: endpoints.modelsUrl,
+		};
+		const fetchedAt = Date.now();
+		saveModelsCache(agentDir, loaded, fetchedAt);
+
+		expect(loadModelsCache(agentDir, "http://relay.api/v1")).toEqual({ ...loaded, fetchedAt });
+		expect(loadModelsCache(agentDir, "http://relay.api/v1/")).toEqual({ ...loaded, fetchedAt });
 	});
 
 	it("writes pretty-printed JSON to disk", () => {

--- a/test/codex-stream.test.ts
+++ b/test/codex-stream.test.ts
@@ -1,0 +1,248 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import type { Api, Context, Model } from "@earendil-works/pi-ai";
+import { describe, expect, it } from "vitest";
+import {
+	applyFastPayloadHook,
+	type CliproxyCodexStreamSimple,
+	createProtocolStreamDispatcher,
+	detectProtocolFromBaseUrl,
+	ensurePatchedModuleCache,
+	isBunEmbeddedRuntimeEntry,
+	loadCliproxyCodexStreams,
+	loadCliproxyResponsesStreams,
+	patchResponsesSource,
+	withPriorityServiceTier,
+} from "../extensions/codex-stream.ts";
+
+const testContext = { messages: [] } as Context;
+
+function testModel(baseUrl: string): Model<Api> {
+	return { id: "test", provider: "cliproxyapi", baseUrl } as Model<Api>;
+}
+
+describe("isBunEmbeddedRuntimeEntry", () => {
+	it("identifies OMP's virtual Bun executable path", () => {
+		expect(isBunEmbeddedRuntimeEntry("/$bunfs/root/omp-darwin-arm64")).toBe(true);
+		expect(isBunEmbeddedRuntimeEntry("C:\\$bunfs\\root\\omp-windows-x64.exe")).toBe(true);
+		expect(isBunEmbeddedRuntimeEntry("/opt/node_modules/@oh-my-pi/pi-coding-agent/dist/cli.js")).toBe(false);
+		expect(isBunEmbeddedRuntimeEntry("/Users/example/.bun/bin/omp")).toBe(false);
+		expect(isBunEmbeddedRuntimeEntry(undefined)).toBe(false);
+	});
+});
+
+describe("detectProtocolFromBaseUrl", () => {
+	it("detects openai-responses from /v1 baseUrl", () => {
+		expect(detectProtocolFromBaseUrl("http://127.0.0.1:8317/v1")).toBe("openai-responses");
+		expect(detectProtocolFromBaseUrl("http://127.0.0.1:8317/v1/")).toBe("openai-responses");
+		expect(detectProtocolFromBaseUrl("https://relay.proxy.com/api/v1")).toBe("openai-responses");
+		expect(detectProtocolFromBaseUrl("relay.proxy.com:8317/v1")).toBe("openai-responses");
+	});
+
+	it("defaults to openai-codex for non-v1 baseUrl", () => {
+		expect(detectProtocolFromBaseUrl("http://127.0.0.1:8317/backend-api/")).toBe("openai-codex");
+		expect(detectProtocolFromBaseUrl("http://127.0.0.1:8317/")).toBe("openai-codex");
+		expect(detectProtocolFromBaseUrl("http://127.0.0.1:8317")).toBe("openai-codex");
+		expect(detectProtocolFromBaseUrl(undefined)).toBe("openai-codex");
+		expect(detectProtocolFromBaseUrl("")).toBe("openai-codex");
+	});
+});
+
+describe("withPriorityServiceTier", () => {
+	it("injects service_tier: priority into objects", () => {
+		expect(withPriorityServiceTier({ model: "test" })).toEqual({
+			model: "test",
+			service_tier: "priority",
+		});
+	});
+
+	it("leaves non-objects unchanged", () => {
+		expect(withPriorityServiceTier("string")).toBe("string");
+		expect(withPriorityServiceTier(null)).toBeNull();
+		expect(withPriorityServiceTier([1, 2])).toEqual([1, 2]);
+	});
+});
+
+describe("patchResponsesSource", () => {
+	it("injects provider ids into OPENAI_TOOL_CALL_PROVIDERS", () => {
+		const fakeSource =
+			'const OPENAI_TOOL_CALL_PROVIDERS = new Set(["openai", "openai-codex"]);\n//# sourceMappingURL=test.js.map';
+		const patched = patchResponsesSource(fakeSource, ["cliproxyapi", "custom-cpa"]);
+		expect(patched).toContain(
+			'const OPENAI_TOOL_CALL_PROVIDERS = new Set(["openai", "openai-codex", "cliproxyapi", "custom-cpa"]);',
+		);
+		expect(patched).not.toContain("sourceMappingURL");
+	});
+
+	it("throws if OPENAI_TOOL_CALL_PROVIDERS is missing", () => {
+		expect(() => patchResponsesSource("const foo = 1;", ["cliproxyapi"])).toThrow(/OPENAI_TOOL_CALL_PROVIDERS/);
+	});
+});
+
+describe("ensurePatchedModuleCache", () => {
+	it("repairs an existing corrupted cache file", () => {
+		const cacheDir = mkdtempSync(join(tmpdir(), "pi-cpa-cache-repair-test-"));
+		const targetPath = join(cacheDir, "patched.mjs");
+		try {
+			writeFileSync(targetPath, "truncated", "utf8");
+			ensurePatchedModuleCache(targetPath, "export const complete = true;\n");
+			expect(readFileSync(targetPath, "utf8")).toBe("export const complete = true;\n");
+			expect(readdirSync(cacheDir)).toEqual(["patched.mjs"]);
+		} finally {
+			rmSync(cacheDir, { recursive: true, force: true });
+		}
+	});
+
+	it("accepts a concurrent writer that installed the expected cache content", () => {
+		const cacheDir = mkdtempSync(join(tmpdir(), "pi-cpa-cache-race-test-"));
+		const targetPath = join(cacheDir, "patched.mjs");
+		const expected = "export const complete = true;\n";
+		try {
+			expect(() =>
+				ensurePatchedModuleCache(targetPath, expected, {
+					rename: (_temporaryPath, finalPath) => {
+						writeFileSync(finalPath, expected, "utf8");
+						throw Object.assign(new Error("race lost"), { code: "EEXIST" });
+					},
+				}),
+			).not.toThrow();
+			expect(readFileSync(targetPath, "utf8")).toBe(expected);
+			expect(readdirSync(cacheDir)).toEqual(["patched.mjs"]);
+		} finally {
+			rmSync(cacheDir, { recursive: true, force: true });
+		}
+	});
+
+	it("cleans the temporary file when the atomic rename fails", () => {
+		const cacheDir = mkdtempSync(join(tmpdir(), "pi-cpa-cache-failure-test-"));
+		const targetPath = join(cacheDir, "patched.mjs");
+		const renameError = Object.assign(new Error("disk failure"), { code: "EIO" });
+		try {
+			expect(() =>
+				ensurePatchedModuleCache(targetPath, "export const complete = true;\n", {
+					rename: () => {
+						throw renameError;
+					},
+				}),
+			).toThrow(renameError);
+			expect(existsSync(targetPath)).toBe(false);
+			expect(readdirSync(cacheDir)).toEqual([]);
+		} finally {
+			rmSync(cacheDir, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("runtime module loading", () => {
+	it("loads patched codex stream module successfully", async () => {
+		const streams = await loadCliproxyCodexStreams(["cliproxyapi"]);
+		expect(streams).toBeDefined();
+		expect(typeof streams.streamSimple).toBe("function");
+		expect(typeof streams.stream).toBe("function");
+		expect(streams.api).toBe("cliproxyapi-codex-responses");
+	});
+
+	it("loads patched responses stream module successfully", async () => {
+		const streams = await loadCliproxyResponsesStreams(["cliproxyapi"]);
+		expect(streams).toBeDefined();
+		expect(typeof streams.streamSimple).toBe("function");
+		expect(typeof streams.stream).toBe("function");
+		expect(streams.api).toBe("cliproxyapi-codex-responses");
+	});
+
+	it("loads the patched responses module from a standalone Node process", async () => {
+		const marker = `cliproxyapi-standalone-node-test-${process.pid}-${Date.now()}`;
+		await loadCliproxyResponsesStreams([marker]);
+
+		const cacheDir = join(tmpdir(), "pi-cliproxyapi-provider");
+		const generatedPath = readdirSync(cacheDir)
+			.filter((name) => name.startsWith("openai-responses-cpa-") && name.endsWith(".mjs"))
+			.map((name) => join(cacheDir, name))
+			.find((path) => readFileSync(path, "utf8").includes(marker));
+		expect(generatedPath).toBeDefined();
+
+		try {
+			expect(() =>
+				execFileSync(
+					process.execPath,
+					["--input-type=module", "-e", `await import(${JSON.stringify(pathToFileURL(generatedPath!).href)});`],
+					{
+						cwd: tmpdir(),
+						stdio: "pipe",
+					},
+				),
+			).not.toThrow();
+		} finally {
+			if (generatedPath) unlinkSync(generatedPath);
+		}
+	});
+
+	it("fails fast when embedded Bun has no physical responses module", async () => {
+		const previousEntry = process.argv[1];
+		const previousCwd = process.cwd();
+		const isolatedCwd = mkdtempSync(join(tmpdir(), "pi-cpa-embedded-bun-test-"));
+		process.argv[1] = "/$bunfs/root/omp-darwin-arm64";
+		process.chdir(isolatedCwd);
+		try {
+			await expect(loadCliproxyResponsesStreams(["cliproxyapi-embedded-bun-test"])).rejects.toThrow(
+				/embedded Bun.*openai-responses protocol is unavailable/,
+			);
+		} finally {
+			process.chdir(previousCwd);
+			if (previousEntry === undefined) {
+				delete process.argv[1];
+			} else {
+				process.argv[1] = previousEntry;
+			}
+			rmSync(isolatedCwd, { recursive: true, force: true });
+		}
+	});
+
+	it("applies fast payload hook correctly", async () => {
+		const payload = { model: "gpt-4o" };
+		const model = { id: "gpt-4o", provider: "cliproxyapi" } as Model<Api>;
+		const next = await applyFastPayloadHook(payload, model);
+		expect(next).toEqual({ model: "gpt-4o", service_tier: "priority" });
+	});
+
+	it("dispatches between codex and responses through the production dispatcher", () => {
+		let lastUsed = "";
+		const streamResult = {} as ReturnType<CliproxyCodexStreamSimple>;
+		const codexSS: CliproxyCodexStreamSimple = () => {
+			lastUsed = "codex";
+			return streamResult;
+		};
+		const responsesSS: CliproxyCodexStreamSimple = () => {
+			lastUsed = "responses";
+			return streamResult;
+		};
+		const dispatcher = createProtocolStreamDispatcher(codexSS, responsesSS);
+
+		dispatcher(testModel("http://127.0.0.1:8317/v1/"), testContext);
+		expect(lastUsed).toBe("responses");
+
+		dispatcher(testModel("http://127.0.0.1:8317/backend-api/"), testContext);
+		expect(lastUsed).toBe("codex");
+	});
+
+	it("fails clearly instead of routing responses requests through codex when the responses stream is unavailable", () => {
+		const streamResult = {} as ReturnType<CliproxyCodexStreamSimple>;
+		const loaderError = new Error("patched source is incompatible");
+		const dispatcher = createProtocolStreamDispatcher(() => streamResult, undefined, loaderError);
+
+		let thrown: unknown;
+		try {
+			dispatcher(testModel("https://relay.example/v1/"), testContext);
+		} catch (error) {
+			thrown = error;
+		}
+
+		expect(thrown).toMatchObject({
+			message: expect.stringMatching(/openai-responses protocol is unavailable.*patched source is incompatible/),
+			cause: loaderError,
+		});
+	});
+});

--- a/test/codex-stream.test.ts
+++ b/test/codex-stream.test.ts
@@ -1,7 +1,17 @@
+import { Buffer } from "node:buffer";
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+	unlinkSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { pathToFileURL } from "node:url";
 import type { Api, Context, Model } from "@earendil-works/pi-ai";
 import { describe, expect, it } from "vitest";
@@ -14,7 +24,11 @@ import {
 	isBunEmbeddedRuntimeEntry,
 	loadCliproxyCodexStreams,
 	loadCliproxyResponsesStreams,
+	normalizeContextForPatchedPiAi,
 	patchResponsesSource,
+	preparePatchedModuleForImport,
+	resolvePhysicalPiAiModule,
+	resolvePiAiApiSubpath,
 	withPriorityServiceTier,
 } from "../extensions/codex-stream.ts";
 
@@ -31,6 +45,130 @@ describe("isBunEmbeddedRuntimeEntry", () => {
 		expect(isBunEmbeddedRuntimeEntry("/opt/node_modules/@oh-my-pi/pi-coding-agent/dist/cli.js")).toBe(false);
 		expect(isBunEmbeddedRuntimeEntry("/Users/example/.bun/bin/omp")).toBe(false);
 		expect(isBunEmbeddedRuntimeEntry(undefined)).toBe(false);
+	});
+});
+
+describe("preparePatchedModuleForImport", () => {
+	it("bundles patched modules before importing them in embedded Bun runtimes", async () => {
+		const cacheDir = mkdtempSync(join(tmpdir(), "pi-cpa-embedded-bundle-test-"));
+		const entryPath = join(cacheDir, "patched.mjs");
+		const outputPath = join(cacheDir, "patched-bundled.mjs");
+		const dependencyPath = join(cacheDir, "json-parse.js");
+		const dependencyUrl = pathToFileURL(dependencyPath).href;
+		writeFileSync(entryPath, `export { parseStreamingJson } from ${JSON.stringify(dependencyUrl)};\n`, "utf8");
+
+		let receivedOptions: Record<string, unknown> | undefined;
+		try {
+			const resolved = await preparePatchedModuleForImport({
+				entryPath,
+				outputPath,
+				embeddedBun: true,
+				build: async (options) => {
+					receivedOptions = options as unknown as Record<string, unknown>;
+					const plugin = options.plugins?.[0];
+					let resolver: ((args: { path: string }) => { path: string }) | undefined;
+					plugin?.setup({
+						onResolve: (_options, callback) => {
+							resolver = callback;
+						},
+					});
+					expect(resolver?.({ path: dependencyUrl })).toEqual({ path: dependencyPath });
+					return {
+						success: true,
+						logs: [],
+						outputs: [{ text: async () => "export const bundled = true;\n" }],
+					};
+				},
+			});
+
+			expect(resolved).toBe(
+				`data:text/javascript;base64,${Buffer.from("export const bundled = true;\n").toString("base64")}`,
+			);
+			expect(existsSync(outputPath)).toBe(false);
+			expect(receivedOptions).toMatchObject({
+				entrypoints: [entryPath],
+				outdir: cacheDir,
+				target: "bun",
+				format: "esm",
+				naming: "patched-bundled.mjs",
+				write: false,
+			});
+		} finally {
+			rmSync(cacheDir, { recursive: true, force: true });
+		}
+	});
+
+	it("keeps the generated module unchanged outside embedded Bun runtimes", async () => {
+		const entryPath = join(tmpdir(), "pi-cpa-patched.mjs");
+		const outputPath = join(tmpdir(), "pi-cpa-patched-bundled.mjs");
+		const build = async () => {
+			throw new Error("build should not run");
+		};
+		await expect(
+			preparePatchedModuleForImport({
+				entryPath,
+				outputPath,
+				embeddedBun: false,
+				build,
+			}),
+		).resolves.toBe(pathToFileURL(entryPath).href);
+	});
+
+	it("rebuilds an existing embedded bundle before importing it from memory", async () => {
+		const cacheDir = mkdtempSync(join(tmpdir(), "pi-cpa-embedded-rebuild-test-"));
+		const entryPath = join(cacheDir, "patched.mjs");
+		const outputPath = join(cacheDir, "patched-bundled.mjs");
+		writeFileSync(entryPath, "export const entry = true;\n", "utf8");
+		let builds = 0;
+		const build = async () => {
+			builds++;
+			return {
+				success: true,
+				outputs: [{ text: async () => `export const bundled = ${builds};\n` }],
+			};
+		};
+
+		try {
+			await preparePatchedModuleForImport({ entryPath, outputPath, embeddedBun: true, build });
+			const resolved = await preparePatchedModuleForImport({ entryPath, outputPath, embeddedBun: true, build });
+			const latestSource = "export const bundled = 2;\n";
+
+			expect(builds).toBe(2);
+			expect(existsSync(outputPath)).toBe(false);
+			expect(resolved).toBe(`data:text/javascript;base64,${Buffer.from(latestSource).toString("base64")}`);
+		} finally {
+			rmSync(cacheDir, { recursive: true, force: true });
+		}
+	});
+
+	it("ignores a corrupted legacy bundle before importing the rebuilt source", async () => {
+		const cacheDir = mkdtempSync(join(tmpdir(), "pi-cpa-embedded-repair-test-"));
+		const entryPath = join(cacheDir, "patched.mjs");
+		const outputPath = join(cacheDir, "patched-bundled.mjs");
+		const bundledSource = "export const repaired = true;\n";
+		writeFileSync(entryPath, "export const entry = true;\n", "utf8");
+		writeFileSync(outputPath, "corrupted", "utf8");
+
+		try {
+			const resolved = await preparePatchedModuleForImport({
+				entryPath,
+				outputPath,
+				embeddedBun: true,
+				build: async () => ({ success: true, outputs: [{ text: async () => bundledSource }] }),
+			});
+
+			expect(readFileSync(outputPath, "utf8")).toBe("corrupted");
+			expect(resolved).toBe(`data:text/javascript;base64,${Buffer.from(bundledSource).toString("base64")}`);
+		} finally {
+			rmSync(cacheDir, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("resolvePiAiApiSubpath", () => {
+	it("removes a JavaScript extension from package export subpaths", () => {
+		expect(resolvePiAiApiSubpath("openai-responses.js")).toBe("@earendil-works/pi-ai/api/openai-responses");
+		expect(resolvePiAiApiSubpath("openai-codex-responses")).toBe("@earendil-works/pi-ai/api/openai-codex-responses");
 	});
 });
 
@@ -137,6 +275,42 @@ describe("ensurePatchedModuleCache", () => {
 });
 
 describe("runtime module loading", () => {
+	it("normalizes OMP's system prompt array for patched pi-ai streams", () => {
+		const context = { systemPrompt: ["system one", "system two"], messages: [] } as unknown as Context;
+		const normalized = normalizeContextForPatchedPiAi(context);
+
+		expect(normalized).not.toBe(context);
+		expect(normalized.systemPrompt).toBe("system one\n\nsystem two");
+		expect((context as unknown as { systemPrompt: string[] }).systemPrompt).toEqual(["system one", "system two"]);
+	});
+
+	it("applies Responses source patches for OMP runtime entries", async () => {
+		const previousEntry = process.argv[1];
+		const runtimeDir = mkdtempSync(join(tmpdir(), "pi-cpa-omp-patched-loader-test-"));
+		const entryPath = join(runtimeDir, "node_modules", "@oh-my-pi", "pi-coding-agent", "dist", "cli.js");
+		const marker = `cliproxyapi-omp-patched-loader-${process.pid}-${Date.now()}`;
+		const cacheDir = join(tmpdir(), "pi-cliproxyapi-provider");
+		let generatedPath: string | undefined;
+		try {
+			mkdirSync(dirname(entryPath), { recursive: true });
+			writeFileSync(entryPath, "", "utf8");
+			process.argv[1] = entryPath;
+
+			await loadCliproxyResponsesStreams([marker]);
+			generatedPath = readdirSync(cacheDir)
+				.filter((name) => name.startsWith("openai-responses-cpa-") && name.endsWith(".mjs"))
+				.map((name) => join(cacheDir, name))
+				.find((path) => readFileSync(path, "utf8").includes(marker));
+
+			expect(generatedPath).toBeDefined();
+		} finally {
+			if (previousEntry === undefined) delete process.argv[1];
+			else process.argv[1] = previousEntry;
+			if (generatedPath) unlinkSync(generatedPath);
+			rmSync(runtimeDir, { recursive: true, force: true });
+		}
+	});
+
 	it("loads patched codex stream module successfully", async () => {
 		const streams = await loadCliproxyCodexStreams(["cliproxyapi"]);
 		expect(streams).toBeDefined();
@@ -180,7 +354,7 @@ describe("runtime module loading", () => {
 		}
 	});
 
-	it("fails fast when embedded Bun has no physical responses module", async () => {
+	it("fails clearly when embedded Bun does not expose its build API", async () => {
 		const previousEntry = process.argv[1];
 		const previousCwd = process.cwd();
 		const isolatedCwd = mkdtempSync(join(tmpdir(), "pi-cpa-embedded-bun-test-"));
@@ -188,7 +362,7 @@ describe("runtime module loading", () => {
 		process.chdir(isolatedCwd);
 		try {
 			await expect(loadCliproxyResponsesStreams(["cliproxyapi-embedded-bun-test"])).rejects.toThrow(
-				/embedded Bun.*openai-responses protocol is unavailable/,
+				/embedded Bun runtime does not expose Bun\.build/,
 			);
 		} finally {
 			process.chdir(previousCwd);
@@ -244,5 +418,25 @@ describe("runtime module loading", () => {
 			message: expect.stringMatching(/openai-responses protocol is unavailable.*patched source is incompatible/),
 			cause: loaderError,
 		});
+	});
+});
+
+describe("resolvePhysicalPiAiModule", () => {
+	it("resolves physical openai-codex-responses.js file", () => {
+		const resolved = resolvePhysicalPiAiModule("openai-codex-responses.js");
+		expect(resolved.path).toContain("openai-codex-responses.js");
+		expect(resolved.dir).toBeDefined();
+	});
+
+	it("resolves physical openai-responses.js file", () => {
+		const resolved = resolvePhysicalPiAiModule("openai-responses.js");
+		expect(resolved.path).toContain("openai-responses.js");
+		expect(resolved.dir).toBeDefined();
+	});
+
+	it("throws with a descriptive message when the module cannot be found", () => {
+		expect(() => resolvePhysicalPiAiModule("non-existent-module-xyz.js")).toThrow(
+			/Cannot resolve non-existent-module-xyz\.js/,
+		);
 	});
 });

--- a/test/lib.test.ts
+++ b/test/lib.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	AUTH_FILE_NAME,
+	autoDetectProtocol,
 	buildInputModalities,
 	buildThinkingLevelMap,
 	CONFIG_FILE_NAME,
@@ -76,8 +77,8 @@ describe("resolveEndpoints", () => {
 		expect(result.modelsUrl).toBe("http://127.0.0.1:8317/v1/models?client_version=pi");
 	});
 
-	it("rewrites /v1 to /backend-api for inference", () => {
-		const result = resolveEndpoints("http://127.0.0.1:8317/v1");
+	it("rewrites /v1 to /backend-api for inference in openai-codex mode", () => {
+		const result = resolveEndpoints("http://127.0.0.1:8317/v1", "openai-codex");
 		expect(result.inferenceBaseUrl).toBe("http://127.0.0.1:8317/backend-api/");
 		expect(result.modelsUrl).toBe("http://127.0.0.1:8317/v1/models?client_version=pi");
 	});
@@ -90,6 +91,54 @@ describe("resolveEndpoints", () => {
 
 	it("throws on empty baseUrl", () => {
 		expect(() => resolveEndpoints("   ")).toThrow(/baseUrl is empty/);
+	});
+});
+
+describe("autoDetectProtocol", () => {
+	it("detects openai-responses from /v1 path", () => {
+		expect(autoDetectProtocol("http://relay.api/v1")).toBe("openai-responses");
+		expect(autoDetectProtocol("http://relay.api/v1/")).toBe("openai-responses");
+		expect(autoDetectProtocol("http://relay.api:8080/prefix/v1")).toBe("openai-responses");
+	});
+
+	it("defaults to openai-codex for root or /backend-api paths", () => {
+		expect(autoDetectProtocol("http://relay.api")).toBe("openai-codex");
+		expect(autoDetectProtocol("http://relay.api/backend-api")).toBe("openai-codex");
+		expect(autoDetectProtocol("127.0.0.1:8317")).toBe("openai-codex");
+	});
+
+	it("returns openai-codex for empty or malformed input", () => {
+		expect(autoDetectProtocol("")).toBe("openai-codex");
+	});
+});
+
+describe("resolveEndpoints openai-responses mode", () => {
+	it("preserves /v1 as inference base for relay APIs", () => {
+		const result = resolveEndpoints("http://relay.api/v1", "openai-responses");
+		expect(result.inferenceBaseUrl).toBe("http://relay.api/v1/");
+		expect(result.modelsUrl).toBe("http://relay.api/v1/models?client_version=pi");
+		expect(result.rootOrigin).toBe("http://relay.api");
+	});
+
+	it("adds /v1 when only host given in openai-responses mode", () => {
+		const result = resolveEndpoints("http://relay.api", "openai-responses");
+		expect(result.inferenceBaseUrl).toBe("http://relay.api/v1/");
+		expect(result.modelsUrl).toBe("http://relay.api/v1/models?client_version=pi");
+	});
+
+	it("rewrites /backend-api to /v1 for relay APIs", () => {
+		const result = resolveEndpoints("http://relay.api/backend-api", "openai-responses");
+		expect(result.inferenceBaseUrl).toBe("http://relay.api/v1/");
+		expect(result.modelsUrl).toBe("http://relay.api/v1/models?client_version=pi");
+	});
+
+	it("auto-detects openai-responses using autoDetectProtocol and resolveEndpoints together", () => {
+		// Callers combine autoDetectProtocol() + resolveEndpoints() to get the correct URL
+		const url = "http://relay.api/v1";
+		const proto = autoDetectProtocol(url);
+		expect(proto).toBe("openai-responses");
+		const result = resolveEndpoints(url, proto);
+		expect(result.inferenceBaseUrl).toBe("http://relay.api/v1/");
 	});
 });
 

--- a/test/pi-compat.test.ts
+++ b/test/pi-compat.test.ts
@@ -11,6 +11,7 @@ const CLIPROXYAPI_ENV_NAMES = [
 	"CLIPROXYAPI_API_KEY",
 	"CLIPROXYAPI_BASE_URL",
 	"CLIPROXYAPI_FAST",
+	"CLIPROXYAPI_PROTOCOL",
 	"CLIPROXYAPI_PROVIDER_ID",
 	"CLIPROXYAPI_PROVIDER_NAME",
 ] as const;
@@ -77,6 +78,71 @@ function createPiMock(commands: Map<string, Parameters<ExtensionAPI["registerCom
 }
 
 describe("pi 0.82.0 compatibility", () => {
+	it("warns once when /v1 automatically selects openai-responses", async () => {
+		await withTempAgentDir(async (agentDir) => {
+			writeFileSync(
+				join(agentDir, "cliproxyapi.json"),
+				JSON.stringify({ baseUrl: "http://relay.api/v1", apiKey: "stored-key" }),
+				"utf8",
+			);
+
+			const commands = new Map<string, Parameters<ExtensionAPI["registerCommand"]>[1]>();
+			const { pi } = createPiMock(commands);
+			const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(JSON.stringify({ models: [] }), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				}),
+			);
+			const warnMock = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+			try {
+				await providerExtension(pi);
+				const migrationWarnings = warnMock.mock.calls.filter(([message]) =>
+					String(message).includes("Earlier versions treated /v1 as openai-codex"),
+				);
+				expect(migrationWarnings).toHaveLength(1);
+				expect(String(migrationWarnings[0]?.[0])).toMatch(/protocol.*openai-codex/);
+			} finally {
+				warnMock.mockRestore();
+				fetchMock.mockRestore();
+			}
+		});
+	});
+
+	it("does not warn about /v1 migration when the environment selects a protocol", async () => {
+		await withTempAgentDir(async (agentDir) => {
+			writeFileSync(
+				join(agentDir, "cliproxyapi.json"),
+				JSON.stringify({ baseUrl: "http://relay.api/v1", apiKey: "stored-key" }),
+				"utf8",
+			);
+			process.env.CLIPROXYAPI_PROTOCOL = "openai-codex";
+
+			const commands = new Map<string, Parameters<ExtensionAPI["registerCommand"]>[1]>();
+			const { pi } = createPiMock(commands);
+			const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+				new Response(JSON.stringify({ models: [] }), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				}),
+			);
+			const warnMock = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+			try {
+				await providerExtension(pi);
+				expect(
+					warnMock.mock.calls.some(([message]) =>
+						String(message).includes("Earlier versions treated /v1 as openai-codex"),
+					),
+				).toBe(false);
+			} finally {
+				warnMock.mockRestore();
+				fetchMock.mockRestore();
+			}
+		});
+	});
+
 	it("registers oauth login and /fast without a dedicated /cliproxyapi command", async () => {
 		await withTempAgentDir(async () => {
 			const commands = new Map<string, Parameters<ExtensionAPI["registerCommand"]>[1]>();
@@ -207,12 +273,17 @@ describe("pi 0.82.0 compatibility", () => {
 			);
 			writeFileSync(
 				join(agentDir, "cliproxyapi.json"),
-				JSON.stringify({ baseUrl: "http://127.0.0.1:8317", apiKey: "stored-key" }),
+				JSON.stringify({
+					baseUrl: "http://127.0.0.1:8317/v1",
+					apiKey: "stored-key",
+					protocol: "openai-responses",
+				}),
 				"utf8",
 			);
 
 			const commands = new Map<string, Parameters<ExtensionAPI["registerCommand"]>[1]>();
 			const { pi } = createPiMock(commands);
+			const warnMock = vi.spyOn(console, "warn").mockImplementation(() => {});
 			const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
 				new Response(JSON.stringify({ models: [] }), {
 					status: 200,
@@ -222,6 +293,11 @@ describe("pi 0.82.0 compatibility", () => {
 
 			try {
 				await expect(providerExtension(pi)).resolves.toBeUndefined();
+				expect(
+					warnMock.mock.calls.some(([message]) =>
+						String(message).includes("Earlier versions treated /v1 as openai-codex"),
+					),
+				).toBe(false);
 				expect(fetchMock).toHaveBeenCalled();
 				expect(commands.size).toBe(4);
 				expect(commands.has("fast")).toBe(true);
@@ -233,9 +309,13 @@ describe("pi 0.82.0 compatibility", () => {
 					"cliproxyapi",
 					expect.objectContaining({
 						oauth: expect.any(Object),
+						headers: {
+							"X-Codex-Beta-Features": "remote_compaction_v2",
+						},
 					}),
 				);
 			} finally {
+				warnMock.mockRestore();
 				fetchMock.mockRestore();
 			}
 		});


### PR DESCRIPTION
## Dependency

Depends on #18. This is a stacked PR: until #18 lands, GitHub also displays its first commit. The OMP-specific commit is `4c84b0c` and changes only `extensions/codex-stream.ts` and `test/codex-stream.test.ts`. Review the [focused OMP diff](https://github.com/junit/pi-cliproxyapi-provider/compare/baf4b5c47d26f6a7bf39318f665ccbbca47216b7...4c84b0c9840e1498018977af058ca09cb7b93fde). After #18 is merged, this branch will be rebased onto the updated `main` so the PR reduces to the OMP-specific change.

## Summary

- locate physical `pi-ai` protocol modules across Pi bundled runtimes, OMP, nested installs, and common package roots
- avoid blocking `import.meta.resolve` calls from `/$bunfs/` entries and normalize package export subpaths
- bundle physical modules with `Bun.build` and import the result from an in-memory data URL, avoiding Bun temp-directory snapshot failures
- normalize OMP `string[]` system prompts at the patched-runtime boundary while preserving official Pi string contexts
- keep Codex and Responses source patches, custom provider/API metadata, Fast payload hooks, and Pi transport options intact

## Verification

- `npm run check`: 9 test files, 132 tests passed
- synthetic integration with the current #15, #16, and #17 heads: 9 test files, 138 tests passed
- OMP 18.0.6, `openai-codex`: `OMP_RUNTIME_OK`
- OMP 18.0.6, forced `openai-responses`: `OMP_RESPONSES_OK`
- Standards review: no documented-standard violations; remaining notes are non-blocking structural refactoring suggestions
- Issue/spec review: PASS

Fixes the remaining bundled-runtime and OMP compatibility cases described in #14.
