### PR TITLE
fix: cancel model refresh on session shutdown

### DIFF
--- a/extensions/index.ts
+++ b/extensions/index.ts
@@ -75,6 +75,12 @@ class ModelRefreshCoordinator {
 	isCurrent(generation: number): boolean {
 		return this.generation === generation;
 	}
+
+	cancel(): void {
+		this.activeController?.abort();
+		this.activeController = undefined;
+		this.generation += 1;
+	}
 }
 
 function logWarn(message: string): void {
@@ -620,6 +626,7 @@ export default async function (pi: ExtensionAPI): Promise<void> {
 	}
 	const fastMode = new FastModeController(fastEnabled);
 	const modelRefreshCoordinator = new ModelRefreshCoordinator();
+	pi.on("session_shutdown", () => modelRefreshCoordinator.cancel());
 
 	let streamSimple: CliproxyCodexStreamSimple;
 	try {


### PR DESCRIPTION
## Summary
Cancels in-flight catalog refresh when the Pi session shuts down.

## Problem
While testing an unrelated change to my pi setup I used /reload in rapid succession and hit the following error in `pi-cliproxyapi-provider`:


```[pi-cliproxyapi-provider] failed to refresh cached models (This extension ctx is stale after session replacement or reload. Do not use a captured pi or command ctx after ctx.newSession(), ctx.fork(), ctx.switchSession(), or ctx.reload(). For newSession, fork, and switchSession, move post-replacement work into withSession and use the ctx passed to withSession. For reload, do not use the old ctx after await ctx.reload().); keeping the cached model list.```

This seems to be a race condition that can happen when `/reload` is triggered while the model catalog refresh is in flight. 

The plugin serves the catalog from cache on session start, `extensions/index.ts:714-715` fires off a refresh, which might be in-flight while `/reload` tears down the `ExtensionAPI` instance used in `index.ts:700`.


## Reproduction
- Start a Pi session with `pi-cliproxyapi-provider`.
- Repeatedly run `/reload` in quick succession.

## Fix
The proposed fix here cancels and discards any outstanding refresh request immediately when Pi's session is shut down.

## Validation

`npm run check` passes:

- TypeScript typecheck
- Biome lint
- 8 test files / 95 tests
