### PR TITLE
Resolve dynamic model context and output capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pi-cliproxyapi-provider
 
-Pi provider extension that discovers models from [CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI) and registers them for use in pi. It supports catalog-driven OpenAI Fast mode and also ships a small TUI helper that shows elapsed runtime and a TPS summary after each agent turn.
+Pi provider extension that discovers models from [CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI) and registers them for use in pi. It supports catalog-driven OpenAI Fast mode and also ships a small TUI helper that shows elapsed runtime and a TPS summary after each agent turn. This release requires pi `>=0.84.3` for the native provider model-refresh lifecycle.
 
 ## What it does
 
@@ -10,7 +10,7 @@ Pi provider extension that discovers models from [CLIProxyAPI](https://github.co
 4. Maps the CLIProxyAPI catalog into pi models, including canonical context/output capabilities and Fast service-tier support.
 5. Registers inference against `{root}/backend-api/`.
 6. Provides `/fast` to toggle OpenAI priority processing for supported models.
-7. Caches the model catalog in `~/.pi/agent/cliproxyapi-models.json`, refreshes it in the background on startup, and provides `/cliproxyapi-refresh` to force a refresh.
+7. Caches the model catalog in `~/.pi/agent/cliproxyapi-models.json` and exposes one native pi `refreshModels` lifecycle for startup, background, `/fast`, and `/cliproxyapi-refresh` updates.
 8. In interactive TUI sessions, shows footer elapsed time during runs and a TPS / token usage toast when the agent settles.
 
 ## Install
@@ -146,7 +146,7 @@ Each invocation switches Fast between on and off and writes the result to `~/.pi
 
 When Fast is effective, pi's model status appends a yellow lowercase `fast`, for example `gpt-5.6-sol • xhigh • fast`. When Fast is off or the selected model is unsupported, the original model status remains unchanged. Supported models do not produce a separate status notification. Running `/fast` with an unsupported model still updates the global preference; enabling it warns that the current model cannot use Fast.
 
-Fast capability is catalog-driven: the plugin considers a CLIProxyAPI model Fast-capable when its `service_tiers` field is a non-empty array. The `additional_speed_tiers` field is ignored. For supported models, Fast injects `service_tier: "priority"`; unsupported models are left unchanged. Fast is independent from pi's reasoning/thinking level. When `models.dev` provides `experimental.modes.fast.cost`, the registered model cost switches to those Fast rates as well; the provider is refreshed when `/fast` is toggled. If no Fast price is published, the standard price is retained. The plugin does not guess Fast prices from `-pro`/`-fast` model IDs.
+Fast capability is catalog-driven: the plugin considers a CLIProxyAPI model Fast-capable when its `service_tiers` field is a non-empty array. The `additional_speed_tiers` field is ignored. For supported models, Fast injects `service_tier: "priority"`; unsupported models are left unchanged. Fast is independent from pi's reasoning/thinking level. When `models.dev` provides `experimental.modes.fast.cost`, the registered model cost switches to those Fast rates as well; `/fast` asks pi to run the provider's native model refresh and reactivates the current model with the refreshed metadata. If no Fast price is published, the standard price is retained. The plugin does not guess Fast prices from `-pro`/`-fast` model IDs.
 
 ## Pausing provider requests
 
@@ -182,14 +182,16 @@ The cache stores only model metadata and derived endpoint URLs — including eac
 
 When the provider loads (including session resume):
 
-1. If a cache exists for the configured `baseUrl`, its models are registered immediately. A remote query to `{root}/v1/models?client_version=pi` then runs in the background; on success, the cache is rewritten and the registered model list is refreshed. If the query fails, the existing cache remains active.
-2. If no matching cache exists, the remote query runs synchronously. On success, the cache is written and the fetched models are registered. If it fails, startup logs a warning and no models are registered until the proxy responds.
+1. If a cache exists for the configured `baseUrl`, the native provider callback restores it immediately. Once the session starts, pi runs the same callback with network access in the background; success atomically replaces the catalog and rewrites the cache, while failure leaves the stale cache active.
+2. If no matching cache exists, startup invokes the same callback synchronously with network access so normal startup and `pi --list-models` can see the CLIProxyAPI catalog. On failure, startup logs a warning and keeps the last in-memory list unchanged.
+
+Pi owns refresh cancellation and publication generations. `/cliproxyapi-refresh`, `/fast`, and Pi-initiated model refreshes all call this same lifecycle; they do not unregister or re-register the provider, so its OAuth, auth fallback, stream handler, and runtime identity stay intact.
 
 Use `/cliproxyapi-refresh` to force an immediate remote refresh of the model catalog.
 
 ### Refresh commands
 
-- `/cliproxyapi-refresh` — force an immediate remote refresh of the model catalog, rewrite the cache, and update registered models. Use this after adding or removing models on the proxy without restarting pi.
+- `/cliproxyapi-refresh` — ask pi to force the provider's native refresh callback, rewrite the cache, update the catalog, and reactivate the current model with fresh pricing/capability metadata. Use this after adding or removing models on the proxy without restarting pi.
 - `/login CLIProxyAPI` / `/login cliproxyapi` — re-entering credentials always forces a fresh models query and rewrites the cache.
 
 Delete `~/.pi/agent/cliproxyapi-models.json` to clear the cache manually.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Pi provider extension that discovers models from [CLIProxyAPI](https://github.co
 1. Registers a provider that always appears in `/login` (account sign-in path).
 2. Interactive setup collects `baseUrl` + `apiKey` via `/login CLIProxyAPI` or `/login cliproxyapi`.
 3. Fetches `{root}/v1/models?client_version=pi`.
-4. Maps the CLIProxyAPI catalog into pi models, including Fast service-tier capability.
+4. Maps the CLIProxyAPI catalog into pi models, including canonical context/output capabilities and Fast service-tier support.
 5. Registers inference against `{root}/backend-api/`.
 6. Provides `/fast` to toggle OpenAI priority processing for supported models.
 7. Caches the model catalog in `~/.pi/agent/cliproxyapi-models.json`, refreshes it in the background on startup, and provides `/cliproxyapi-refresh` to force a refresh.
@@ -170,7 +170,7 @@ The provider keeps a separate cache file so startup stays fast when CLIProxyAPI 
 
 `~/.pi/agent/cliproxyapi-models.json`
 
-The cache stores only model metadata and derived endpoint URLs — the model list, Fast-capable IDs, `inferenceBaseUrl`, `modelsUrl`, and a `fetchedAt` timestamp. It **never** stores your API key or other credentials.
+The cache stores only model metadata and derived endpoint URLs — including each model's resolved `contextWindow` / `maxTokens`, Fast-capable IDs, `inferenceBaseUrl`, `modelsUrl`, and a `fetchedAt` timestamp. It **never** stores your API key or other credentials.
 
 | Property | Value |
 |----------|-------|
@@ -202,14 +202,23 @@ From CPA catalog entry → pi model:
 | ----------- | ---------- |
 | `slug` | `id` |
 | `display_name` | `name` |
-| `context_window` | `contextWindow` |
+| `context_window` / `max_context_window` | `contextWindow` |
+| `max_completion_tokens` / `max_tokens` | `maxTokens` |
 | `input_modalities` | `input` (`text` / `image`) |
 | `supported_reasoning_levels[].effort` | `thinkingLevelMap` + `reasoning` |
 | `visibility: "hide"` | skipped |
 
-Unsupported pi thinking levels are set to `null` so they are hidden in the UI. When available, prices are matched against canonical model entries in `models.dev`; `cost.tiers[].tier.size` becomes pi's `inputTokensAbove`, including thresholds such as `272000`. The legacy `context_over_200k` field is used only when no explicit tiers are present. Ambiguous reseller prices are not selected arbitrarily and fall back to zero. These are catalog/list prices, not a guarantee of CPA's own markup or billing.
+Unsupported pi thinking levels are set to `null` so they are hidden in the UI. Model limits and prices are resolved against canonical model entries in `models.dev`; `limit.context` / `limit.output` supply missing capabilities, and `cost.tiers[].tier.size` becomes pi's `inputTokensAbove`, including thresholds such as `272000`. The legacy `context_over_200k` field is used only when no explicit tiers are present. Ambiguous reseller prices are not selected arbitrarily and fall back to zero. These are catalog/list prices, not a guarantee of CPA's own markup or billing.
 
-The raw `models.dev` response is cached for 24 hours at `~/.pi/agent/tmp/models-dev-cache.json`. A fresh cache avoids the network request; an expired cache is refreshed with a three-second timeout, and stale data is retained if refresh fails. If neither the network nor a previous cache is available, pricing safely falls back to zero. A small explicit alias table covers known CLIProxyAPI variants such as `gemini-pro-agent` → `gemini-3.1-pro-preview`; unknown variants are not guessed.
+Capability resolution uses one fail-closed priority order:
+
+1. Positive `context_window` / `max_context_window` and `max_completion_tokens` / `max_tokens` explicitly returned by CLIProxyAPI.
+2. Exact canonical model metadata from `models.dev`, including the small explicit alias layer used for known proxy IDs such as `gemini-pro-agent` → `gemini-3.1-pro-preview`.
+3. Conservative defaults: 128,000 context and 16,384 max output.
+
+CLIProxyAPI's generated Pi catalog can assign both context fields the same generic 272,000-token template. That pair is not treated as an explicit model limit: an exact canonical match replaces it, while an unknown model falls back conservatively. The 272,000 value is retained when the same canonical entry publishes a 272,000 context price tier, preserving intentionally constrained models such as the GPT-5.6 short-context tier. Capability matching never uses normalized or fuzzy lookalikes; only exact IDs, namespace-stripped exact IDs, and documented aliases are eligible.
+
+The raw `models.dev` response is shared by capability and pricing resolution and cached for 24 hours at `~/.pi/agent/tmp/models-dev-cache.json`. A fresh cache avoids the network request; an expired cache is refreshed with a three-second timeout, and stale data is retained if refresh fails. If neither the network nor a previous cache is available, capabilities use the server's trusted explicit values or conservative defaults, while pricing falls back to zero.
 
 ## Migration from static models.json
 
@@ -240,4 +249,6 @@ Disable just this helper via `pi config` if you only want the CLIProxyAPI provid
   - HTTP 200 (including empty catalog) → credentials are persisted
   - non-200 / network / invalid baseUrl → nothing is persisted; re-enter baseUrl + API key
 - If CPA returns HTTP 200 with zero usable models: login still succeeds; re-run `/login CLIProxyAPI` later after models become available.
+- If the canonical catalog is unavailable, its stale disk cache is reused. With no catalog cache, startup still succeeds and existing models remain available using trusted server capabilities or the conservative 128,000 / 16,384 defaults.
+- Unknown or lookalike model IDs never borrow another model's capabilities.
 - If the selected model does not provide a non-empty `service_tiers` array: the request is left unchanged; `/fast` still updates the global preference and warns when enabling it.

--- a/extensions/auto-compact.ts
+++ b/extensions/auto-compact.ts
@@ -86,6 +86,12 @@ export class ProactiveCompactionController {
 			this.pending = undefined;
 		});
 
+		pi.on("session_before_compact", () => {
+			// Compaction summaries use the same provider stream. Clear the synthetic
+			// overflow before pi invokes the summarizer so it cannot abort compaction.
+			this.pending = undefined;
+		});
+
 		pi.on("session_compact", () => {
 			this.pending = undefined;
 		});

--- a/extensions/codex-stream.ts
+++ b/extensions/codex-stream.ts
@@ -5,6 +5,7 @@
  * - extractAccountId never throws; plain API keys are allowed
  * - chatgpt-account-id header is omitted when account id is unavailable
  * - provider id(s) are added to CODEX_TOOL_CALL_PROVIDERS for tool-call id handling
+ * - replayed duplicate tool-call identities are deterministically disambiguated
  * - model/message api id uses cliproxyapi-codex-responses
  *
  * The patched module is derived at runtime from the installed
@@ -40,6 +41,103 @@ export interface CliproxyCodexStreamOptions {
 
 type PayloadHook = NonNullable<SimpleStreamOptions["onPayload"]>;
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function allocateDuplicateIdentity(
+	original: string,
+	ordinal: number,
+	reserved: ReadonlySet<string>,
+	allocated: Set<string>,
+): string {
+	let candidateOrdinal = ordinal;
+	while (true) {
+		const suffix = `_pi_${candidateOrdinal}`;
+		const candidate = `${original.slice(0, 64 - suffix.length)}${suffix}`;
+		if (!reserved.has(candidate) && !allocated.has(candidate)) {
+			allocated.add(candidate);
+			return candidate;
+		}
+		candidateOrdinal++;
+	}
+}
+
+/**
+ * Make replayed Responses function-call identities unique while preserving each
+ * call/output pair. Upstream conversion has already flattened history here, so
+ * sequential pairing also covers synthetic outputs inserted for adjacent calls.
+ */
+export function normalizeResponsesToolCallIdentities(payload: unknown): unknown {
+	if (!isRecord(payload) || !Array.isArray(payload.input)) {
+		return payload;
+	}
+
+	const input = payload.input;
+	const reservedCallIds = new Set<string>();
+	const reservedItemIds = new Set<string>();
+	for (const item of input) {
+		if (!isRecord(item) || item.type !== "function_call") continue;
+		if (typeof item.call_id === "string") reservedCallIds.add(item.call_id);
+		if (typeof item.id === "string") reservedItemIds.add(item.id);
+	}
+
+	const callOccurrences = new Map<string, number>();
+	const itemOccurrences = new Map<string, number>();
+	const allocatedCallIds = new Set<string>();
+	const allocatedItemIds = new Set<string>();
+	const pendingCallIds = new Map<string, string[]>();
+	let changed = false;
+
+	const normalizedInput = input.map((item): unknown => {
+		if (!isRecord(item)) return item;
+
+		if (item.type === "function_call") {
+			const originalCallId = item.call_id;
+			const originalItemId = item.id;
+			let callId = originalCallId;
+			let itemId = originalItemId;
+
+			if (typeof originalCallId === "string") {
+				const ordinal = (callOccurrences.get(originalCallId) ?? 0) + 1;
+				callOccurrences.set(originalCallId, ordinal);
+				const pairedCallId =
+					ordinal === 1
+						? originalCallId
+						: allocateDuplicateIdentity(originalCallId, ordinal, reservedCallIds, allocatedCallIds);
+				callId = pairedCallId;
+				const pending = pendingCallIds.get(originalCallId) ?? [];
+				pending.push(pairedCallId);
+				pendingCallIds.set(originalCallId, pending);
+			}
+
+			if (typeof originalItemId === "string") {
+				const ordinal = (itemOccurrences.get(originalItemId) ?? 0) + 1;
+				itemOccurrences.set(originalItemId, ordinal);
+				if (ordinal > 1) {
+					itemId = allocateDuplicateIdentity(originalItemId, ordinal, reservedItemIds, allocatedItemIds);
+				}
+			}
+
+			if (callId === originalCallId && itemId === originalItemId) return item;
+			changed = true;
+			return { ...item, call_id: callId, id: itemId };
+		}
+
+		if (item.type === "function_call_output" && typeof item.call_id === "string") {
+			const callId = pendingCallIds.get(item.call_id)?.shift();
+			if (callId !== undefined && callId !== item.call_id) {
+				changed = true;
+				return { ...item, call_id: callId };
+			}
+		}
+
+		return item;
+	});
+
+	return changed ? { ...payload, input: normalizedInput } : payload;
+}
+
 export function withPriorityServiceTier(payload: unknown): unknown {
 	if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
 		return payload;
@@ -61,19 +159,22 @@ export async function applyFastPayloadHook(
 	return nextPayload === undefined ? fastPayload : nextPayload;
 }
 
-export function wrapStreamSimpleForFast(
+export function wrapCliproxyCodexStream(
 	streamSimple: CliproxyCodexStreamSimple,
 	shouldUseFast?: (model: Model<Api>) => boolean,
 ): CliproxyCodexStreamSimple {
-	return (model, context, streamOptions) => {
-		if (!shouldUseFast?.(model)) {
-			return streamSimple(model, context, streamOptions);
-		}
-		return streamSimple(model, context, {
+	return (model, context, streamOptions) =>
+		streamSimple(model, context, {
 			...streamOptions,
-			onPayload: (payload, payloadModel) => applyFastPayloadHook(payload, payloadModel, streamOptions?.onPayload),
+			onPayload: async (payload, payloadModel) => {
+				const normalizedPayload = normalizeResponsesToolCallIdentities(payload);
+				if (shouldUseFast?.(model)) {
+					return applyFastPayloadHook(normalizedPayload, payloadModel, streamOptions?.onPayload);
+				}
+				const nextPayload = await streamOptions?.onPayload?.(normalizedPayload, payloadModel);
+				return nextPayload === undefined ? normalizedPayload : nextPayload;
+			},
 		});
-	};
 }
 
 const EXTRACT_ACCOUNT_ID_PATCH = `function extractAccountId(token) {
@@ -284,11 +385,11 @@ export async function loadCliproxyCodexStreams(
 		throw new Error("patched openai-codex-responses module missing streamSimple/stream exports");
 	}
 
-	const streamSimple = wrapStreamSimpleForFast(mod.streamSimple, options.shouldUseFast);
+	const streamSimple = wrapCliproxyCodexStream(mod.streamSimple, options.shouldUseFast);
 
 	return {
 		api: CLIPROXYAPI_CODEX_API,
 		streamSimple,
-		stream: mod.stream,
+		stream: wrapCliproxyCodexStream(mod.stream),
 	};
 }

--- a/extensions/index.ts
+++ b/extensions/index.ts
@@ -34,15 +34,14 @@ import {
 	isUnauthorizedModelsError,
 	loadAuthConnection,
 	loadConfigFile,
-	type PiProviderModel,
 	resolveConnection,
 	resolveEndpoints,
 	resolveFastDefault,
 	resolveIdentity,
-	resolveMappedModels,
 	resolvePauseDefault,
 	saveConfigFile,
 } from "./lib.ts";
+import { ModelCatalogController } from "./model-refresh.ts";
 import type { PauseController } from "./pause.ts";
 import { pauseController, waitForPauseToEnd } from "./pause.ts";
 import { registerTransientNetworkErrorRetry } from "./retry.ts";
@@ -58,23 +57,6 @@ class ConfigPersistenceError extends Error {
 interface RefreshResult {
 	modelCount: number;
 	modelsUrl: string;
-}
-
-class ModelRefreshCoordinator {
-	private generation = 0;
-	private activeController: AbortController | undefined;
-
-	begin(): { generation: number; signal: AbortSignal } {
-		this.activeController?.abort();
-		const controller = new AbortController();
-		this.activeController = controller;
-		this.generation += 1;
-		return { generation: this.generation, signal: controller.signal };
-	}
-
-	isCurrent(generation: number): boolean {
-		return this.generation === generation;
-	}
 }
 
 function logWarn(message: string): void {
@@ -154,43 +136,22 @@ async function promptConnection(
 	return { baseUrlInput, apiKey };
 }
 
-async function configureAndRegister(options: {
-	pi: ExtensionAPI;
+async function configureConnection(options: {
 	agentDir: string;
 	providerId: string;
 	providerName: string;
 	baseUrlInput: string;
 	apiKey: string;
-	defaultBaseUrl: string;
-	streamSimple: CliproxyCodexStreamSimple;
-	fastMode: FastModeController;
-	refreshCoordinator: ModelRefreshCoordinator;
-	onFastModeChange?: (enabled: boolean, ctx: ExtensionContext) => Promise<void>;
+	catalog: ModelCatalogController;
+	signal?: AbortSignal;
 }): Promise<RefreshResult> {
-	const {
-		pi,
-		agentDir,
-		providerId,
-		providerName,
+	const { agentDir, providerId, providerName, baseUrlInput, apiKey, catalog, signal } = options;
+	const connection = {
 		baseUrlInput,
 		apiKey,
-		defaultBaseUrl,
-		streamSimple,
-		fastMode,
-		refreshCoordinator,
-		onFastModeChange,
-	} = options;
-
-	const refresh = refreshCoordinator.begin();
-	const { loaded } = await resolveMappedModels(agentDir, baseUrlInput, apiKey, {
-		forceRefresh: true,
-		fastMode: fastMode.isEnabled(),
-		signal: refresh.signal,
-		shouldCommit: () => refreshCoordinator.isCurrent(refresh.generation),
-	});
-	if (!refreshCoordinator.isCurrent(refresh.generation)) {
-		throw new Error("Model refresh was superseded by a newer request.");
-	}
+		...resolveEndpoints(baseUrlInput),
+	};
+	await catalog.refreshConnection(connection, signal);
 
 	try {
 		saveConfigFile(agentDir, {
@@ -203,47 +164,17 @@ async function configureAndRegister(options: {
 		throw new ConfigPersistenceError(error);
 	}
 
-	// /login stores oauth credentials itself; keep the provider OAuth-only so
-	// `/login <provider>` skips the API-key vs account selector.
-	registerProvider(pi, {
-		providerId,
-		providerName,
-		baseUrlInput,
-		models: loaded.models,
-		defaultBaseUrl: baseUrlInput || defaultBaseUrl,
-		agentDir,
-		streamSimple,
-		fastMode,
-		refreshCoordinator,
-		onFastModeChange,
-	});
-	fastMode.setSupportedModelIds(loaded.fastModelIds);
-
-	return { modelCount: loaded.models.length, modelsUrl: loaded.modelsUrl };
+	return { modelCount: catalog.getModels().length, modelsUrl: connection.modelsUrl };
 }
 
 function createOAuthHandlers(options: {
-	pi: ExtensionAPI;
 	agentDir: string;
 	providerId: string;
 	providerName: string;
 	defaultBaseUrl: string;
-	streamSimple: CliproxyCodexStreamSimple;
-	fastMode: FastModeController;
-	refreshCoordinator: ModelRefreshCoordinator;
-	onFastModeChange?: (enabled: boolean, ctx: ExtensionContext) => Promise<void>;
+	catalog: ModelCatalogController;
 }) {
-	const {
-		pi,
-		agentDir,
-		providerId,
-		providerName,
-		defaultBaseUrl,
-		streamSimple,
-		fastMode,
-		refreshCoordinator,
-		onFastModeChange,
-	} = options;
+	const { agentDir, providerId, providerName, defaultBaseUrl, catalog } = options;
 
 	return {
 		name: providerName,
@@ -260,18 +191,14 @@ function createOAuthHandlers(options: {
 
 				callbacks.onProgress?.("Validating credentials via models endpoint...");
 				try {
-					const result = await configureAndRegister({
-						pi,
+					const result = await configureConnection({
 						agentDir,
 						providerId,
 						providerName,
 						baseUrlInput,
 						apiKey,
-						defaultBaseUrl,
-						streamSimple,
-						fastMode,
-						refreshCoordinator,
-						onFastModeChange,
+						catalog,
+						signal: callbacks.signal,
 					});
 
 					logInfo(`login ok: registered ${result.modelCount} models from ${result.modelsUrl}`);
@@ -326,57 +253,27 @@ function registerProvider(
 		providerName: string;
 		baseUrlInput: string;
 		apiKey?: string;
-		models?: PiProviderModel[];
 		defaultBaseUrl: string;
 		agentDir: string;
 		streamSimple: CliproxyCodexStreamSimple;
-		fastMode: FastModeController;
-		refreshCoordinator?: ModelRefreshCoordinator;
-		onFastModeChange?: (enabled: boolean, ctx: ExtensionContext) => Promise<void>;
+		catalog: ModelCatalogController;
 	},
 ): void {
-	const {
-		providerId,
-		providerName,
-		baseUrlInput,
-		apiKey,
-		models,
-		defaultBaseUrl,
-		agentDir,
-		streamSimple,
-		fastMode,
-		onFastModeChange,
-	} = options;
-	const refreshCoordinator = options.refreshCoordinator ?? new ModelRefreshCoordinator();
-
+	const { providerId, providerName, baseUrlInput, apiKey, defaultBaseUrl, agentDir, streamSimple, catalog } = options;
 	const endpoints = resolveEndpoints(baseUrlInput);
-	const oauth = createOAuthHandlers({
-		pi,
-		agentDir,
-		providerId,
-		providerName,
-		defaultBaseUrl,
-		streamSimple,
-		fastMode,
-		refreshCoordinator,
-		onFastModeChange,
-	});
-
-	// Replace any previous registration so an earlier ambient apiKey does not linger
-	// via registerProvider merge semantics and reintroduce the auth-type selector.
-	pi.unregisterProvider(providerId);
+	const oauth = createOAuthHandlers({ agentDir, providerId, providerName, defaultBaseUrl, catalog });
 
 	pi.registerProvider(providerId, {
 		name: providerName,
 		baseUrl: endpoints.inferenceBaseUrl,
 		api: CLIPROXYAPI_CODEX_API,
 		streamSimple,
-		// OAuth-only keeps `/login <provider>` on the multi-field account path.
-		// Pass apiKey only for ambient request auth when no /login credential exists
-		// (config file / env). Never pass both for /login flows.
+		// Keep stored /login credentials OAuth-only; ambient config/env setups
+		// retain their request apiKey fallback without changing refresh identity.
 		oauth,
 		...(apiKey ? { apiKey } : {}),
-		...(models && models.length > 0 ? { models } : {}),
+		models: catalog.getModels(),
+		refreshModels: catalog.refreshModels,
 	});
 }
 
@@ -507,28 +404,29 @@ export function registerFastCommand(options: {
 	});
 }
 
+async function activateRefreshedCurrentModel(
+	pi: ExtensionAPI,
+	ctx: ExtensionContext,
+	providerId: string,
+): Promise<void> {
+	const currentModel = ctx.model;
+	if (!currentModel || currentModel.provider !== providerId) return;
+	const refreshedModel = ctx.modelRegistry.find(providerId, currentModel.id);
+	if (!refreshedModel) {
+		throw new Error(`Refreshed model ${providerId}/${currentModel.id} is unavailable`);
+	}
+	if (!(await pi.setModel(refreshedModel))) {
+		throw new Error(`Unable to activate refreshed model ${providerId}/${currentModel.id}`);
+	}
+}
+
 export function registerRefreshCommand(options: {
 	pi: ExtensionAPI;
 	agentDir: string;
 	providerId: string;
 	providerName: string;
-	defaultBaseUrl: string;
-	streamSimple: CliproxyCodexStreamSimple;
-	fastMode: FastModeController;
-	refreshCoordinator?: ModelRefreshCoordinator;
-	onRefresh?: (connection: NonNullable<ReturnType<typeof resolveConnection>>) => Promise<RefreshResult | undefined>;
 }): void {
-	const {
-		pi,
-		agentDir,
-		providerId,
-		providerName,
-		defaultBaseUrl,
-		streamSimple,
-		fastMode,
-		refreshCoordinator,
-		onRefresh,
-	} = options;
+	const { pi, agentDir, providerId, providerName } = options;
 
 	pi.registerCommand("cliproxyapi-refresh", {
 		description: "Force refresh CLIProxyAPI models from the remote catalog.",
@@ -548,39 +446,13 @@ export function registerRefreshCommand(options: {
 			}
 
 			try {
-				let result: RefreshResult | undefined;
-				if (onRefresh) {
-					result = await onRefresh(connection);
-					if (!result) return;
-				} else {
-					const refresh = refreshCoordinator?.begin();
-					const { loaded } = await resolveMappedModels(agentDir, connection.baseUrlInput, connection.apiKey, {
-						forceRefresh: true,
-						fastMode: fastMode.isEnabled(),
-						signal: refresh?.signal,
-						shouldCommit: refresh ? () => refreshCoordinator?.isCurrent(refresh.generation) ?? true : undefined,
-					});
-					if (refresh && !refreshCoordinator?.isCurrent(refresh.generation)) return;
-					fastMode.setSupportedModelIds(loaded.fastModelIds);
-
-					const hasStoredLogin = hasLoginCredential(agentDir, providerId);
-					registerProvider(pi, {
-						providerId,
-						providerName,
-						baseUrlInput: connection.baseUrlInput,
-						apiKey: hasStoredLogin ? undefined : connection.apiKey,
-						models: loaded.models,
-						defaultBaseUrl,
-						agentDir,
-						streamSimple,
-						fastMode,
-						refreshCoordinator,
-					});
-
-					result = { modelCount: loaded.models.length, modelsUrl: loaded.modelsUrl };
-				}
-
-				ctx.ui.notify(`Refreshed ${result.modelCount} CLIProxyAPI models from ${result.modelsUrl}.`, "info");
+				const refresh = await ctx.modelRegistry.refresh({ providers: [providerId], force: true });
+				const error = refresh.errors.get(providerId);
+				if (error) throw error;
+				if (refresh.aborted) return;
+				await activateRefreshedCurrentModel(pi, ctx, providerId);
+				const modelCount = ctx.modelRegistry.getProvider(providerId)?.getModels().length ?? 0;
+				ctx.ui.notify(`Refreshed ${modelCount} CLIProxyAPI models from ${connection.modelsUrl}.`, "info");
 			} catch (error) {
 				const message = error instanceof Error ? error.message : String(error);
 				ctx.ui.notify(`Failed to refresh CLIProxyAPI models: ${message}`, "error");
@@ -619,7 +491,6 @@ export default async function (pi: ExtensionAPI): Promise<void> {
 		logWarn(`invalid Fast configuration (${message}); using fast=false`);
 	}
 	const fastMode = new FastModeController(fastEnabled);
-	const modelRefreshCoordinator = new ModelRefreshCoordinator();
 
 	let streamSimple: CliproxyCodexStreamSimple;
 	try {
@@ -633,12 +504,35 @@ export default async function (pi: ExtensionAPI): Promise<void> {
 		return;
 	}
 
+	const catalog = new ModelCatalogController(agentDir, fastMode, () =>
+		resolveConnection(agentDir, identity.providerId),
+	);
+	const connection = resolveConnection(agentDir, identity.providerId);
+	let startupFromCache = false;
+	if (connection) {
+		try {
+			startupFromCache = await catalog.initialize(connection);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			if (isUnauthorizedModelsError(error)) {
+				logWarn(`models request unauthorized (${message}). Use /login ${identity.providerName} to reconfigure.`);
+			} else {
+				logWarn(
+					`failed to load models (${message}). Use /login ${identity.providerName} or check ${CONFIG_FILE_NAME} / CLIPROXYAPI_* env vars.`,
+				);
+			}
+		}
+	}
+
 	const fastFooter = new FastFooterController(identity.providerId, fastMode, () =>
 		proactiveCompaction.getCompactionSettings(),
 	);
-	let refreshModelsForFast: ((ctx: ExtensionContext) => Promise<void>) | undefined;
-	const onFastModeChange = async (_enabled: boolean, ctx: ExtensionContext): Promise<void> => {
-		await refreshModelsForFast?.(ctx);
+	const refreshNativeModels = async (ctx: ExtensionContext): Promise<void> => {
+		const refresh = await ctx.modelRegistry.refresh({ providers: [identity.providerId], force: true });
+		const error = refresh.errors.get(identity.providerId);
+		if (error) throw error;
+		if (refresh.aborted) return;
+		await activateRefreshedCurrentModel(pi, ctx, identity.providerId);
 	};
 	registerFastCommand({
 		pi,
@@ -646,106 +540,45 @@ export default async function (pi: ExtensionAPI): Promise<void> {
 		providerId: identity.providerId,
 		fastMode,
 		onStatusChange: (ctx) => fastFooter.refresh(ctx),
-		onModeChange: onFastModeChange,
+		onModeChange: async (_enabled, ctx) => refreshNativeModels(ctx),
 	});
 	fastFooter.register(pi);
 
-	// Always register oauth so the provider is visible in /login immediately after install.
+	const hasStoredLogin = hasLoginCredential(agentDir, identity.providerId);
 	registerProvider(pi, {
 		providerId: identity.providerId,
 		providerName: identity.providerName,
-		baseUrlInput: defaultBaseUrl,
+		baseUrlInput: connection?.baseUrlInput ?? defaultBaseUrl,
+		apiKey: connection && !hasStoredLogin ? connection.apiKey : undefined,
 		defaultBaseUrl,
 		agentDir,
 		streamSimple,
-		fastMode,
-		refreshCoordinator: modelRefreshCoordinator,
-		onFastModeChange: onFastModeChange,
+		catalog,
 	});
 	registerTransientNetworkErrorRetry(pi, identity.providerId);
-
-	const connection = resolveConnection(agentDir, identity.providerId);
-	const registerConfiguredProvider = async (
-		currentConnection: NonNullable<ReturnType<typeof resolveConnection>>,
-		options: { forceRefresh?: boolean } = {},
-	): Promise<RefreshResult | undefined> => {
-		const refresh = modelRefreshCoordinator.begin();
-		try {
-			const { loaded, fromCache } = await resolveMappedModels(
-				agentDir,
-				currentConnection.baseUrlInput,
-				currentConnection.apiKey,
-				{
-					forceRefresh: options.forceRefresh,
-					fastMode: fastMode.isEnabled(),
-					signal: refresh.signal,
-					shouldCommit: () => modelRefreshCoordinator.isCurrent(refresh.generation),
-				},
-			);
-			if (!modelRefreshCoordinator.isCurrent(refresh.generation)) return undefined;
-
-			fastMode.setSupportedModelIds(loaded.fastModelIds);
-
-			// Prefer OAuth-only registration when /login already stored credentials so
-			// `/login <provider>` jumps straight into the multi-field flow. Fall back to
-			// ambient apiKey only for config-file / env setups without auth.json.
-			const hasStoredLogin = hasLoginCredential(agentDir, identity.providerId);
-			registerProvider(pi, {
-				providerId: identity.providerId,
-				providerName: identity.providerName,
-				baseUrlInput: currentConnection.baseUrlInput,
-				apiKey: hasStoredLogin ? undefined : currentConnection.apiKey,
-				models: loaded.models,
-				defaultBaseUrl,
-				agentDir,
-				streamSimple,
-				fastMode,
-				refreshCoordinator: modelRefreshCoordinator,
-				onFastModeChange,
-			});
-
-			if (fromCache && !options.forceRefresh) {
-				void registerConfiguredProvider(currentConnection, { forceRefresh: true }).catch((error) => {
-					const message = error instanceof Error ? error.message : String(error);
-					logWarn(`failed to refresh cached models (${message}); keeping the cached model list.`);
-				});
-			}
-
-			return { modelCount: loaded.models.length, modelsUrl: loaded.modelsUrl };
-		} catch (error) {
-			if (!modelRefreshCoordinator.isCurrent(refresh.generation)) return undefined;
-			throw error;
-		}
-	};
-	refreshModelsForFast = async (ctx: ExtensionContext): Promise<void> => {
-		const currentConnection = resolveConnection(agentDir, identity.providerId);
-		if (!currentConnection) return;
-
-		const refreshed = await registerConfiguredProvider(currentConnection, { forceRefresh: true });
-		if (!refreshed) return;
-		const currentModel = ctx.model;
-		if (!currentModel || currentModel.provider !== identity.providerId) return;
-
-		const refreshedModel = ctx.modelRegistry.find(identity.providerId, currentModel.id);
-		if (!refreshedModel) {
-			throw new Error(`Refreshed model ${identity.providerId}/${currentModel.id} is unavailable`);
-		}
-		if (JSON.stringify(refreshedModel.cost) === JSON.stringify(currentModel.cost)) return;
-		if (!(await pi.setModel(refreshedModel))) {
-			throw new Error(`Unable to activate refreshed model ${identity.providerId}/${currentModel.id}`);
-		}
-	};
 	registerRefreshCommand({
 		pi,
 		agentDir,
 		providerId: identity.providerId,
 		providerName: identity.providerName,
-		defaultBaseUrl,
-		streamSimple,
-		fastMode,
-		refreshCoordinator: modelRefreshCoordinator,
-		onRefresh: (currentConnection) => registerConfiguredProvider(currentConnection, { forceRefresh: true }),
 	});
+
+	if (startupFromCache) {
+		pi.on("session_start", (_event, ctx) => {
+			void ctx.modelRegistry
+				.refresh({ providers: [identity.providerId] })
+				.then((refresh) => {
+					const error = refresh.errors.get(identity.providerId);
+					if (error) {
+						logWarn(`failed to refresh cached models (${error.message}); keeping the cached model list.`);
+					}
+				})
+				.catch((error) => {
+					const message = error instanceof Error ? error.message : String(error);
+					logWarn(`failed to start cached model refresh (${message}); keeping the cached model list.`);
+				});
+		});
+	}
 
 	if (!connection) {
 		logInfo(
@@ -753,19 +586,5 @@ export default async function (pi: ExtensionAPI): Promise<void> {
 				`Menu path: /login → Sign in with an account → ${identity.providerName}. ` +
 				`Or set ${CONFIG_FILE_NAME} / CLIPROXYAPI_API_KEY.`,
 		);
-		return;
-	}
-
-	try {
-		await registerConfiguredProvider(connection);
-	} catch (error) {
-		const message = error instanceof Error ? error.message : String(error);
-		if (isUnauthorizedModelsError(error)) {
-			logWarn(`models request unauthorized (${message}). Use /login ${identity.providerName} to reconfigure.`);
-		} else {
-			logWarn(
-				`failed to load models (${message}). Use /login ${identity.providerName} or check ${CONFIG_FILE_NAME} / CLIPROXYAPI_* env vars.`,
-			);
-		}
 	}
 }

--- a/extensions/lib.ts
+++ b/extensions/lib.ts
@@ -71,6 +71,8 @@ export interface CodexClientModel {
 	description?: string;
 	context_window?: number;
 	max_context_window?: number;
+	max_tokens?: number;
+	max_completion_tokens?: number;
 	input_modalities?: string[];
 	supported_reasoning_levels?: CodexReasoningLevel[] | string[];
 	default_service_tier?: string | null;
@@ -139,16 +141,26 @@ interface ModelsDevModePayload {
 
 interface ModelsDevModelPayload {
 	cost?: ModelsDevCostPayload;
+	limit?: {
+		context?: unknown;
+		output?: unknown;
+	};
 	experimental?: {
 		modes?: Record<string, ModelsDevModePayload | undefined>;
 	};
 }
 
+export interface CanonicalModelCapabilities {
+	contextWindow: number;
+	maxTokens: number;
+}
+
 export interface ModelsDevCostEntry {
 	providerId: string;
 	modelId: string;
-	standard: PiProviderCost;
+	standard?: PiProviderCost;
 	fast?: PiProviderCost;
+	capabilities?: CanonicalModelCapabilities;
 }
 
 export interface ModelsDevCostCatalog {
@@ -476,12 +488,7 @@ export function toPiModel(
 
 	const efforts = extractReasoningEfforts(model);
 	const hasReasoning = efforts.some((effort) => effort !== "none");
-	const contextWindow =
-		(typeof model.context_window === "number" && model.context_window > 0 ? model.context_window : undefined) ??
-		(typeof model.max_context_window === "number" && model.max_context_window > 0
-			? model.max_context_window
-			: undefined) ??
-		DEFAULT_CONTEXT_WINDOW;
+	const capabilities = resolveModelCapabilities(model, costCatalog);
 
 	const cost = costCatalog
 		? matchModelCost(id, costCatalog, fastMode && supportsFastServiceTier(model))
@@ -493,8 +500,7 @@ export function toPiModel(
 		reasoning: hasReasoning,
 		input: buildInputModalities(model),
 		cost,
-		contextWindow,
-		maxTokens: DEFAULT_MAX_TOKENS,
+		...capabilities,
 		thinkingLevelMap: buildThinkingLevelMap(efforts),
 	};
 }
@@ -583,8 +589,10 @@ const MODEL_PROVIDER_PREFERENCES: Array<{ pattern: RegExp; providers: string[] }
 	{ pattern: /^llama-/, providers: ["meta"] },
 ];
 
-/** Explicit aliases for proxy-specific model ids whose billable base model is known. */
-const MODEL_PRICE_ALIASES: Record<string, string[]> = {
+const MODEL_CAPABILITY_PROVIDER_PREFERENCES = [{ pattern: /^(?:kimi-|moonshot-)/, providers: ["neon"] }];
+
+/** Explicit aliases for proxy-specific ids with a confirmed canonical model. */
+const MODEL_CANONICAL_ALIASES: Record<string, string[]> = {
 	"gemini-pro-agent": ["gemini-3.1-pro-preview"],
 	"gemini-3.1-pro-low": ["gemini-3.1-pro-preview"],
 	"gemini-3.6-flash-high": ["gemini-3.6-flash"],
@@ -685,6 +693,13 @@ function preferredProvidersForModel(modelId: string): string[] {
 	return uniqueStrings([namespace ?? "", ...familyProviders]);
 }
 
+function preferredCapabilityProviders(modelId: string): string[] {
+	const normalizedId = stripModelNamespace(modelId);
+	const canonical =
+		MODEL_CAPABILITY_PROVIDER_PREFERENCES.find(({ pattern }) => pattern.test(normalizedId))?.providers ?? [];
+	return uniqueStrings([...canonical, ...preferredProvidersForModel(modelId)]);
+}
+
 function addCatalogEntry(catalog: Map<string, ModelsDevCostEntry[]>, key: string, entry: ModelsDevCostEntry): void {
 	if (!key) return;
 	const entries = catalog.get(key) ?? [];
@@ -726,20 +741,81 @@ function findDirectModelsDevEntry(modelId: string, catalog: ModelsDevCostCatalog
 	const rawId = modelId.trim().toLowerCase();
 	const exactKeys = uniqueStrings([rawId, stripModelNamespace(rawId)]);
 	for (const key of exactKeys) {
-		const match = selectModelsDevEntry(catalog.exact.get(key) ?? [], modelId);
+		const entries = (catalog.exact.get(key) ?? []).filter((entry) => entry.standard !== undefined);
+		const match = selectModelsDevEntry(entries, modelId);
 		if (match) return match;
 	}
-	return selectModelsDevEntry(catalog.normalized.get(normalizeModelKey(rawId)) ?? [], modelId);
+	const normalizedEntries = (catalog.normalized.get(normalizeModelKey(rawId)) ?? []).filter(
+		(entry) => entry.standard !== undefined,
+	);
+	return selectModelsDevEntry(normalizedEntries, modelId);
 }
 
 function findModelsDevEntry(modelId: string, catalog: ModelsDevCostCatalog): ModelsDevCostEntry | undefined {
 	const rawId = modelId.trim().toLowerCase();
-	const lookupIds = uniqueStrings([rawId, ...(MODEL_PRICE_ALIASES[rawId] ?? [])]);
+	const lookupIds = uniqueStrings([rawId, ...(MODEL_CANONICAL_ALIASES[rawId] ?? [])]);
 	for (const lookupId of lookupIds) {
 		const match = findDirectModelsDevEntry(lookupId, catalog);
 		if (match) return match;
 	}
 	return undefined;
+}
+
+function sameCapabilityVariants(entries: ModelsDevCostEntry[]): boolean {
+	return new Set(entries.map((entry) => JSON.stringify(entry.capabilities))).size === 1;
+}
+
+function findCanonicalCapabilityEntry(modelId: string, catalog: ModelsDevCostCatalog): ModelsDevCostEntry | undefined {
+	const rawId = modelId.trim().toLowerCase();
+	const lookupIds = uniqueStrings([rawId, ...(MODEL_CANONICAL_ALIASES[rawId] ?? [])]);
+	for (const lookupId of lookupIds) {
+		const exactKeys = uniqueStrings([lookupId, stripModelNamespace(lookupId)]);
+		for (const key of exactKeys) {
+			const entries = (catalog.exact.get(key) ?? []).filter((entry) => entry.capabilities !== undefined);
+			const preferredProviders = preferredCapabilityProviders(lookupId);
+			for (const providerId of preferredProviders) {
+				const preferred = entries.find((entry) => entry.providerId === providerId);
+				if (preferred) return preferred;
+			}
+			if (entries.length === 1 || sameCapabilityVariants(entries)) {
+				return [...entries].sort((a, b) => a.providerId.localeCompare(b.providerId))[0];
+			}
+		}
+	}
+	return undefined;
+}
+
+const CLIPROXY_SYNTHETIC_CONTEXT_WINDOW = 272_000;
+
+function positiveNumber(value: unknown): number | undefined {
+	return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : undefined;
+}
+
+/**
+ * Capability priority: explicit non-template CLIProxy values, exact/known-alias
+ * canonical metadata, then conservative defaults. The 272K template is retained
+ * only when the canonical price catalog confirms an intentional 272K tier.
+ */
+export function resolveModelCapabilities(
+	model: CodexClientModel,
+	catalog?: ModelsDevCostCatalog,
+): CanonicalModelCapabilities {
+	const id = codexModelId(model);
+	const canonical = id && catalog ? findCanonicalCapabilityEntry(id, catalog) : undefined;
+	const serverContext = positiveNumber(model.context_window) ?? positiveNumber(model.max_context_window);
+	const isSyntheticTemplate =
+		serverContext === CLIPROXY_SYNTHETIC_CONTEXT_WINDOW &&
+		positiveNumber(model.context_window) === CLIPROXY_SYNTHETIC_CONTEXT_WINDOW &&
+		positiveNumber(model.max_context_window) === CLIPROXY_SYNTHETIC_CONTEXT_WINDOW;
+	const hasMatchingContextTier =
+		canonical?.standard?.tiers?.some((tier) => tier.inputTokensAbove === CLIPROXY_SYNTHETIC_CONTEXT_WINDOW) ?? false;
+	const trustedServerContext = !isSyntheticTemplate || hasMatchingContextTier ? serverContext : undefined;
+	const serverMaxTokens = positiveNumber(model.max_completion_tokens) ?? positiveNumber(model.max_tokens);
+
+	return {
+		contextWindow: trustedServerContext ?? canonical?.capabilities?.contextWindow ?? DEFAULT_CONTEXT_WINDOW,
+		maxTokens: serverMaxTokens ?? canonical?.capabilities?.maxTokens ?? DEFAULT_MAX_TOKENS,
+	};
 }
 
 interface ModelsDevCacheFile {
@@ -796,9 +872,13 @@ function buildCatalogFromProviders(providers: Record<string, unknown>): ModelsDe
 		for (const [modelId, modelValue] of Object.entries(models)) {
 			const model = asRecord(modelValue) as ModelsDevModelPayload | undefined;
 			const standard = parseModelsDevCost(model?.cost);
-			if (!standard) continue;
 			const fast = parseModelsDevCost(model?.experimental?.modes?.fast?.cost);
-			addModelsDevEntry(catalog, { providerId, modelId, standard, fast });
+			const contextWindow = positiveNumber(model?.limit?.context);
+			const maxTokens = positiveNumber(model?.limit?.output);
+			const capabilities =
+				contextWindow !== undefined && maxTokens !== undefined ? { contextWindow, maxTokens } : undefined;
+			if (!standard && !capabilities) continue;
+			addModelsDevEntry(catalog, { providerId, modelId, standard, fast, capabilities });
 		}
 	}
 	return catalog;
@@ -843,8 +923,8 @@ export async function fetchModelsDevCostMap(
 
 export function matchModelCost(modelId: string, costCatalog: ModelsDevCostCatalog, isFastMode = false): PiProviderCost {
 	const entry = findModelsDevEntry(modelId, costCatalog);
-	if (!entry) return { ...ZERO_COST };
-	return cloneCost(isFastMode && entry.fast ? entry.fast : entry.standard);
+	const cost = isFastMode && entry?.fast ? entry.fast : entry?.standard;
+	return cost ? cloneCost(cost) : { ...ZERO_COST };
 }
 
 export async function loadMappedModels(

--- a/extensions/model-refresh.ts
+++ b/extensions/model-refresh.ts
@@ -1,0 +1,124 @@
+import type { RefreshModelsContext } from "@earendil-works/pi-ai";
+import type { FastModeController } from "./fast.ts";
+import { loadModelsCache, type PiProviderModel, type ResolvedConnection, resolveMappedModels } from "./lib.ts";
+
+class RefreshGeneration {
+	private generation = 0;
+	private activeController: AbortController | undefined;
+
+	begin(parentSignal: AbortSignal): { generation: number; signal: AbortSignal } {
+		this.activeController?.abort();
+		const controller = new AbortController();
+		this.activeController = controller;
+		this.generation += 1;
+		return {
+			generation: this.generation,
+			signal: AbortSignal.any([parentSignal, controller.signal]),
+		};
+	}
+
+	isCurrent(generation: number): boolean {
+		return this.generation === generation;
+	}
+}
+
+function directRefreshContext(allowNetwork: boolean, signal: AbortSignal): RefreshModelsContext {
+	return {
+		allowNetwork,
+		...(allowNetwork ? { force: true } : {}),
+		signal,
+		publish: async ({ update }) => {
+			if (signal.aborted) return false;
+			update?.();
+			return true;
+		},
+	};
+}
+
+/**
+ * Owns the extension's stable catalog reference and its single Pi refresh seam.
+ * Pi supplies lifecycle contexts after registration; startup and login use the
+ * same callback with a direct context before Pi can initiate a refresh.
+ */
+export class ModelCatalogController {
+	private readonly models: PiProviderModel[] = [];
+	private readonly refreshGeneration = new RefreshGeneration();
+
+	constructor(
+		private readonly agentDir: string,
+		private readonly fastMode: FastModeController,
+		private readonly resolveConnection: () => ResolvedConnection | null,
+	) {}
+
+	getModels(): PiProviderModel[] {
+		return this.models;
+	}
+
+	/** Cache-first startup; only a cache miss blocks on the remote catalog. */
+	async initialize(connection: ResolvedConnection, signal = new AbortController().signal): Promise<boolean> {
+		await this.refreshModels(directRefreshContext(false, signal), connection);
+		const fromCache = this.hasMatchingCache(connection);
+		if (!fromCache && !signal.aborted) {
+			await this.refreshModels(directRefreshContext(true, signal), connection);
+		}
+		return fromCache;
+	}
+
+	/** Validate an unpersisted /login connection through the canonical refresh callback. */
+	async refreshConnection(connection: ResolvedConnection, signal = new AbortController().signal): Promise<void> {
+		await this.refreshModels(directRefreshContext(true, signal), connection);
+	}
+
+	/** Legacy extension shape adapted by Pi into Provider.refreshModels. */
+	readonly refreshModels = async (
+		context: RefreshModelsContext,
+		connectionOverride?: ResolvedConnection,
+	): Promise<PiProviderModel[]> => {
+		const connection = connectionOverride ?? this.resolveConnection();
+		if (!connection) return this.models;
+
+		const refresh = this.refreshGeneration.begin(context.signal);
+		if (!context.allowNetwork) {
+			const cached = loadModelsCache(this.agentDir, connection.baseUrlInput);
+			if (cached && this.cacheMatchesFastMode(cached.fastMode)) {
+				await context.publish({
+					update: () => this.publish(cached.models, cached.fastModelIds, refresh.generation, refresh.signal),
+				});
+			}
+			return this.models;
+		}
+
+		try {
+			const { loaded } = await resolveMappedModels(this.agentDir, connection.baseUrlInput, connection.apiKey, {
+				forceRefresh: true,
+				fastMode: this.fastMode.isEnabled(),
+				signal: refresh.signal,
+				shouldCommit: () => this.refreshGeneration.isCurrent(refresh.generation),
+			});
+			await context.publish({
+				update: () => this.publish(loaded.models, loaded.fastModelIds, refresh.generation, refresh.signal),
+			});
+			return this.models;
+		} catch (error) {
+			// A direct startup/login refresh can supersede a Pi-owned generation.
+			// In that case Pi should retain the current list, not report a false failure.
+			if (!context.signal.aborted && !this.refreshGeneration.isCurrent(refresh.generation)) return this.models;
+			throw error;
+		}
+	};
+
+	private hasMatchingCache(connection: ResolvedConnection): boolean {
+		const cached = loadModelsCache(this.agentDir, connection.baseUrlInput);
+		return cached !== null && this.cacheMatchesFastMode(cached.fastMode);
+	}
+
+	private cacheMatchesFastMode(cachedFastMode: boolean | undefined): boolean {
+		return (cachedFastMode ?? false) === this.fastMode.isEnabled();
+	}
+
+	private publish(models: PiProviderModel[], fastModelIds: string[], generation: number, signal: AbortSignal): void {
+		if (signal.aborted || !this.refreshGeneration.isCurrent(generation)) return;
+		this.models.splice(0, this.models.length, ...models);
+		this.fastMode.setSupportedModelIds(fastModelIds);
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
 			},
 			"peerDependencies": {
 				"@earendil-works/pi-ai": "*",
-				"@earendil-works/pi-coding-agent": ">=0.82.0"
+				"@earendil-works/pi-coding-agent": ">=0.84.3"
 			}
 		},
 		"node_modules/@anthropic-ai/sdk": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@router-for-me/pi-cliproxyapi-provider",
-	"version": "1.4.13",
+	"version": "1.4.15",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@router-for-me/pi-cliproxyapi-provider",
-			"version": "1.4.13",
+			"version": "1.4.15",
 			"license": "MIT",
 			"devDependencies": {
 				"@biomejs/biome": "2.5.3",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 	},
 	"peerDependencies": {
 		"@earendil-works/pi-ai": "*",
-		"@earendil-works/pi-coding-agent": ">=0.82.0"
+		"@earendil-works/pi-coding-agent": ">=0.84.3"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.5.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@router-for-me/pi-cliproxyapi-provider",
-	"version": "1.4.14",
+	"version": "1.4.15",
 	"description": "Pi provider extension that auto-registers CLIProxyAPI models, plus TUI elapsed/TPS status",
 	"type": "module",
 	"keywords": [

--- a/test/auto-compact.test.ts
+++ b/test/auto-compact.test.ts
@@ -132,6 +132,14 @@ describe("proactive compaction controller", () => {
 		expect(wrapped(model, { messages: [] })).toBe(baseResult);
 	});
 
+	it("does not inject the pending overflow into compaction summarization", async () => {
+		const { ctx, handlers, model, wrapped, baseResult } = setup();
+		await handlers.get("turn_end")?.({ message: assistantMessage(THRESHOLD + 1), toolResults: [{}] }, ctx);
+
+		await handlers.get("session_before_compact")?.({}, ctx);
+		expect(wrapped(model, { messages: [] })).toBe(baseResult);
+	});
+
 	it("reloads settings before scheduling", async () => {
 		const { ctx, handlers, model, wrapped, baseResult, settingsPath } = setup();
 		writeFileSync(

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -1,8 +1,13 @@
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { Api, Model } from "@earendil-works/pi-ai";
-import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import type { Api, Model, RefreshModelsContext } from "@earendil-works/pi-ai";
+import type {
+	ExtensionAPI,
+	ExtensionCommandContext,
+	ExtensionContext,
+	ProviderConfig,
+} from "@earendil-works/pi-coding-agent";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import providerExtension from "../extensions/index.ts";
 import {
@@ -104,19 +109,73 @@ async function withTempAgentDir(run: (agentDir: string) => Promise<void>): Promi
 	}
 }
 
-function createPiMock(commands = new Map<string, Parameters<ExtensionAPI["registerCommand"]>[1]>()): {
-	pi: ExtensionAPI;
-	commands: Map<string, Parameters<ExtensionAPI["registerCommand"]>[1]>;
-} {
+function createPiMock(commands = new Map<string, Parameters<ExtensionAPI["registerCommand"]>[1]>()) {
+	let providerConfig: ProviderConfig | undefined;
+	let refreshController: AbortController | undefined;
+	const sessionStartHandlers: Array<(event: unknown, ctx: ExtensionContext) => unknown> = [];
 	const pi = {
 		registerCommand: vi.fn((name: string, options: Parameters<ExtensionAPI["registerCommand"]>[1]) => {
 			commands.set(name, options);
 		}),
 		unregisterProvider: vi.fn(),
-		registerProvider: vi.fn(),
-		on: vi.fn(),
+		registerProvider: vi.fn((_providerId: string, config: ProviderConfig) => {
+			providerConfig = config;
+		}),
+		on: vi.fn((event: string, handler: (event: unknown, ctx: ExtensionContext) => unknown) => {
+			if (event === "session_start") sessionStartHandlers.push(handler);
+		}),
+		setModel: vi.fn(async () => true),
 	} as unknown as ExtensionAPI;
-	return { pi, commands };
+
+	const models = (): Model<Api>[] =>
+		(providerConfig?.models ?? []).map((model) => ({
+			...model,
+			provider: "cliproxyapi",
+			api: providerConfig?.api ?? "openai-codex-responses",
+			baseUrl: providerConfig?.baseUrl ?? "http://127.0.0.1:8317/backend-api/",
+		})) as Model<Api>[];
+	const modelRegistry = {
+		refresh: vi.fn(async (options: { force?: boolean } = {}) => {
+			refreshController?.abort();
+			const controller = new AbortController();
+			refreshController = controller;
+			const errors = new Map<string, Error>();
+			const callback = providerConfig?.refreshModels;
+			if (callback) {
+				const run = async (allowNetwork: boolean): Promise<void> => {
+					const context: RefreshModelsContext = {
+						allowNetwork,
+						...(allowNetwork && options.force ? { force: true } : {}),
+						signal: controller.signal,
+						publish: async ({ update }) => {
+							if (controller.signal.aborted) return false;
+							update?.();
+							return true;
+						},
+					};
+					const refreshed = await callback(context);
+					if (!controller.signal.aborted && providerConfig) providerConfig.models = refreshed;
+				};
+				try {
+					await run(false);
+					if (!controller.signal.aborted) await run(true);
+				} catch (error) {
+					if (!controller.signal.aborted) {
+						errors.set("cliproxyapi", error instanceof Error ? error : new Error(String(error)));
+					}
+				}
+			}
+			return { aborted: controller.signal.aborted, errors };
+		}),
+		find: (providerId: string, modelId: string) =>
+			models().find((model) => model.provider === providerId && model.id === modelId),
+		getProvider: (providerId: string) => (providerId === "cliproxyapi" ? { getModels: models } : undefined),
+	};
+	const emitCatalogSessionStart = async (): Promise<void> => {
+		const ctx = { modelRegistry, ui: { notify: vi.fn() } } as unknown as ExtensionContext;
+		await sessionStartHandlers.at(-1)?.({ type: "session_start" }, ctx);
+	};
+	return { pi, commands, modelRegistry, emitCatalogSessionStart, getProviderConfig: () => providerConfig };
 }
 
 afterEach(() => {
@@ -381,33 +440,26 @@ describe("provider startup cache behavior", () => {
 				}
 				return remoteResponse;
 			});
-			const { pi, commands } = createPiMock();
+			const { pi, commands, emitCatalogSessionStart, getProviderConfig } = createPiMock();
 
 			try {
 				await expect(providerExtension(pi)).resolves.toBeUndefined();
-				expect(fetchMock).toHaveBeenCalledTimes(2);
+				expect(fetchMock).not.toHaveBeenCalled();
 				expect(commands.has("cliproxyapi-refresh")).toBe(true);
+				expect(getProviderConfig()?.models?.map((model) => model.id)).toEqual(["startup-cached"]);
+				expect(pi.registerProvider).toHaveBeenCalledTimes(1);
+				expect(pi.unregisterProvider).not.toHaveBeenCalled();
 
-				const initialCallsWithModels = (
-					(pi.registerProvider as ReturnType<typeof vi.fn>).mock.calls as Array<
-						[string, { models?: PiProviderModel[] }]
-					>
-				).filter(([, config]) => config.models && config.models.length > 0);
-				expect(initialCallsWithModels[0]?.[1].models?.map((model: PiProviderModel) => model.id)).toEqual([
-					"startup-cached",
-				]);
-
+				await emitCatalogSessionStart();
+				await new Promise<void>((resolve) => setTimeout(resolve, 0));
+				expect(fetchMock).toHaveBeenCalledTimes(2);
 				releaseRemote(
 					new Response(JSON.stringify({ models: [createCodexModel("background-fresh", true)] }), { status: 200 }),
 				);
 				await waitForAsyncRefresh();
 
-				const refreshedCallsWithModels = (
-					(pi.registerProvider as ReturnType<typeof vi.fn>).mock.calls as Array<
-						[string, { models?: PiProviderModel[] }]
-					>
-				).filter(([, config]) => config.models && config.models.length > 0);
-				expect(refreshedCallsWithModels.at(-1)?.[1].models?.[0].id).toBe("background-fresh");
+				expect(getProviderConfig()?.models?.[0]?.id).toBe("background-fresh");
+				expect(pi.registerProvider).toHaveBeenCalledTimes(1);
 				const diskCache = loadModelsCache(agentDir, "http://127.0.0.1:8317");
 				expect(diskCache?.models[0].id).toBe("background-fresh");
 				expect(diskCache?.fastModelIds).toEqual(["background-fresh"]);
@@ -436,13 +488,15 @@ describe("provider startup cache behavior", () => {
 				if (modelRequestCount === 1) return backgroundResponse;
 				return new Response(JSON.stringify({ models: [createCodexModel("newer")] }), { status: 200 });
 			});
-			const { pi, commands } = createPiMock();
+			const { pi, commands, modelRegistry, emitCatalogSessionStart, getProviderConfig } = createPiMock();
 
 			try {
 				await providerExtension(pi);
+				await emitCatalogSessionStart();
+				await new Promise<void>((resolve) => setTimeout(resolve, 0));
 				const refresh = commands.get("cliproxyapi-refresh")!;
 				const notify = vi.fn();
-				await refresh.handler("", { ui: { notify } } as unknown as ExtensionCommandContext);
+				await refresh.handler("", { modelRegistry, ui: { notify } } as unknown as ExtensionCommandContext);
 
 				const diskCacheAfterNewerRefresh = loadModelsCache(agentDir, "http://127.0.0.1:8317");
 				expect(diskCacheAfterNewerRefresh?.models[0]?.id).toBe("newer");
@@ -452,12 +506,8 @@ describe("provider startup cache behavior", () => {
 
 				const diskCacheAfterOlderRefresh = loadModelsCache(agentDir, "http://127.0.0.1:8317");
 				expect(diskCacheAfterOlderRefresh?.models[0]?.id).toBe("newer");
-				const callsWithModels = (
-					(pi.registerProvider as ReturnType<typeof vi.fn>).mock.calls as Array<
-						[string, { models?: PiProviderModel[] }]
-					>
-				).filter(([, config]) => config.models && config.models.length > 0);
-				expect(callsWithModels.at(-1)?.[1].models?.[0]?.id).toBe("newer");
+				expect(getProviderConfig()?.models?.[0]?.id).toBe("newer");
+				expect(pi.registerProvider).toHaveBeenCalledTimes(1);
 			} finally {
 				fetchMock.mockRestore();
 			}
@@ -471,19 +521,14 @@ describe("provider startup cache behavior", () => {
 			saveModelsCache(agentDir, cached, 1);
 
 			const fetchMock = vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("network down"));
-			const { pi } = createPiMock();
+			const { pi, emitCatalogSessionStart, getProviderConfig } = createPiMock();
 
 			try {
 				await expect(providerExtension(pi)).resolves.toBeUndefined();
+				await emitCatalogSessionStart();
 				await waitForAsyncRefresh();
 				expect(fetchMock).toHaveBeenCalledTimes(2);
-
-				const callsWithModels = (
-					(pi.registerProvider as ReturnType<typeof vi.fn>).mock.calls as Array<
-						[string, { models?: PiProviderModel[] }]
-					>
-				).filter(([, config]) => config.models && config.models.length > 0);
-				expect(callsWithModels[0]?.[1].models?.[0].id).toBe("startup-fallback");
+				expect(getProviderConfig()?.models?.[0]?.id).toBe("startup-fallback");
 				const diskCache = loadModelsCache(agentDir, "http://127.0.0.1:8317");
 				expect(diskCache?.models[0].id).toBe("startup-fallback");
 			} finally {
@@ -543,19 +588,22 @@ describe("/cliproxyapi-refresh command", () => {
 						new Response(JSON.stringify({ models: [createCodexModel("refreshed", true)] }), { status: 200 }),
 					),
 				);
-			const { pi, commands } = createPiMock();
+			const { pi, commands, modelRegistry } = createPiMock();
 
 			try {
 				await providerExtension(pi);
 				const refresh = commands.get("cliproxyapi-refresh")!;
 				const notify = vi.fn();
 				const model = { id: "refreshed", provider: "cliproxyapi" } as Model<Api>;
-				const ctx = { model, ui: { notify } } as unknown as ExtensionCommandContext;
+				const ctx = { model, modelRegistry, ui: { notify } } as unknown as ExtensionCommandContext;
 
 				await refresh.handler("", ctx);
 
-				expect(fetchMock).toHaveBeenCalledTimes(4);
+				expect(fetchMock).toHaveBeenCalledTimes(2);
 				expect(notify).toHaveBeenCalledWith(expect.stringContaining("Refreshed 1 CLIProxyAPI models"), "info");
+				expect(pi.setModel).toHaveBeenCalledWith(expect.objectContaining({ id: "refreshed" }));
+				expect(pi.registerProvider).toHaveBeenCalledTimes(1);
+				expect(pi.unregisterProvider).not.toHaveBeenCalled();
 
 				const diskCache = loadModelsCache(agentDir, "http://127.0.0.1:8317");
 				expect(diskCache?.models[0].id).toBe("refreshed");
@@ -573,14 +621,14 @@ describe("/cliproxyapi-refresh command", () => {
 			const fetchMock = vi
 				.spyOn(globalThis, "fetch")
 				.mockResolvedValue(new Response(JSON.stringify({ error: "unauthorized" }), { status: 401 }));
-			const { pi, commands } = createPiMock();
+			const { pi, commands, modelRegistry } = createPiMock();
 
 			try {
 				await providerExtension(pi);
 				const refresh = commands.get("cliproxyapi-refresh")!;
 				const notify = vi.fn();
 				const model = { id: "any", provider: "cliproxyapi" } as Model<Api>;
-				const ctx = { model, ui: { notify } } as unknown as ExtensionCommandContext;
+				const ctx = { model, modelRegistry, ui: { notify } } as unknown as ExtensionCommandContext;
 
 				await refresh.handler("", ctx);
 

--- a/test/capabilities.test.ts
+++ b/test/capabilities.test.ts
@@ -1,0 +1,258 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	DEFAULT_CONTEXT_WINDOW,
+	DEFAULT_MAX_TOKENS,
+	fetchModelsDevCostMap,
+	loadMappedModels,
+	loadModelsCache,
+	resolveMappedModels,
+	toPiModel,
+} from "../extensions/lib.ts";
+
+const tempDirs: string[] = [];
+
+function tempAgentDir(): string {
+	const dir = mkdtempSync(join(tmpdir(), "pi-cliproxyapi-capabilities-"));
+	tempDirs.push(dir);
+	return dir;
+}
+
+function response(providers: Record<string, unknown>): Response {
+	return new Response(JSON.stringify(providers), {
+		status: 200,
+		headers: { "Content-Type": "application/json" },
+	});
+}
+
+async function catalog(providers: Record<string, unknown>) {
+	const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(response(providers));
+	try {
+		return await fetchModelsDevCostMap(tempAgentDir(), true);
+	} finally {
+		fetchMock.mockRestore();
+	}
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	while (tempDirs.length > 0) {
+		const dir = tempDirs.pop();
+		if (dir) rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+describe("canonical model capability resolution", () => {
+	it("replaces CLIProxy's synthetic 272K template for Kimi K3", async () => {
+		const canonical = await catalog({
+			moonshotai: {
+				models: {
+					"kimi-k3": {
+						limit: { context: 1_048_576, output: 131_072 },
+						cost: { input: 3, output: 15 },
+					},
+				},
+			},
+			neon: {
+				models: {
+					"kimi-k3": {
+						limit: { context: 1_048_576, output: 65_536 },
+						cost: { input: 3, output: 15 },
+					},
+				},
+			},
+		});
+
+		const model = toPiModel(
+			{
+				slug: "kimi-k3",
+				context_window: 272_000,
+				max_context_window: 272_000,
+			},
+			canonical,
+		);
+
+		expect(model).toMatchObject({ contextWindow: 1_048_576, maxTokens: 65_536 });
+	});
+
+	it("prefers explicit non-template server capabilities", async () => {
+		const canonical = await catalog({
+			moonshotai: {
+				models: {
+					"kimi-k3": { limit: { context: 1_048_576, output: 65_536 } },
+				},
+			},
+		});
+
+		const model = toPiModel(
+			{
+				slug: "kimi-k3",
+				context_window: 524_288,
+				max_completion_tokens: 32_768,
+			},
+			canonical,
+		);
+
+		expect(model).toMatchObject({ contextWindow: 524_288, maxTokens: 32_768 });
+	});
+
+	it("preserves a 272K server limit backed by a canonical context price tier", async () => {
+		const canonical = await catalog({
+			openai: {
+				models: {
+					"gpt-5.6-sol": {
+						limit: { context: 1_050_000, output: 128_000 },
+						cost: {
+							input: 5,
+							output: 30,
+							tiers: [{ input: 10, output: 45, tier: { type: "context", size: 272_000 } }],
+						},
+					},
+				},
+			},
+		});
+
+		const model = toPiModel(
+			{
+				slug: "gpt-5.6-sol",
+				context_window: 272_000,
+				max_context_window: 272_000,
+			},
+			canonical,
+		);
+
+		expect(model).toMatchObject({ contextWindow: 272_000, maxTokens: 128_000 });
+	});
+
+	it("consumes the server max_tokens field", () => {
+		const model = toPiModel({ slug: "server-model", context_window: 200_000, max_tokens: 40_000 });
+		expect(model).toMatchObject({ contextWindow: 200_000, maxTokens: 40_000 });
+	});
+
+	it("fills both limits from the canonical catalog when the server omits them", async () => {
+		const canonical = await catalog({
+			anthropic: {
+				models: {
+					"claude-example": { limit: { context: 300_000, output: 24_000 } },
+				},
+			},
+		});
+
+		expect(toPiModel({ slug: "claude-example" }, canonical)).toMatchObject({
+			contextWindow: 300_000,
+			maxTokens: 24_000,
+		});
+	});
+
+	it("uses the existing explicit alias layer for canonical capabilities", async () => {
+		const canonical = await catalog({
+			google: {
+				models: {
+					"gemini-3.1-pro-preview": { limit: { context: 1_048_576, output: 65_536 } },
+				},
+			},
+		});
+
+		expect(toPiModel({ slug: "gemini-pro-agent" }, canonical)).toMatchObject({
+			contextWindow: 1_048_576,
+			maxTokens: 65_536,
+		});
+	});
+
+	it("fails closed for unknown models and does not trust the 272K template", async () => {
+		const canonical = await catalog({
+			moonshotai: {
+				models: {
+					"kimi-k3": { limit: { context: 1_048_576, output: 65_536 } },
+				},
+			},
+		});
+
+		const model = toPiModel(
+			{
+				slug: "kimi-k3-lookalike",
+				context_window: 272_000,
+				max_context_window: 272_000,
+			},
+			canonical,
+		);
+
+		expect(model).toMatchObject({
+			contextWindow: DEFAULT_CONTEXT_WINDOW,
+			maxTokens: DEFAULT_MAX_TOKENS,
+		});
+	});
+
+	it("uses safe defaults when no canonical catalog is available", () => {
+		const model = toPiModel({
+			slug: "unknown-model",
+			context_window: 272_000,
+			max_context_window: 272_000,
+		});
+		expect(model).toMatchObject({ contextWindow: DEFAULT_CONTEXT_WINDOW, maxTokens: DEFAULT_MAX_TOKENS });
+	});
+
+	it("retains stale canonical capabilities when catalog refresh is unavailable", async () => {
+		const agentDir = tempAgentDir();
+		const fetchMock = vi.spyOn(globalThis, "fetch");
+		fetchMock.mockResolvedValueOnce(
+			response({
+				moonshotai: {
+					models: {
+						"kimi-k3": { limit: { context: 1_048_576, output: 65_536 } },
+					},
+				},
+			}),
+		);
+		await fetchModelsDevCostMap(agentDir);
+		fetchMock.mockRejectedValueOnce(new Error("catalog offline"));
+
+		const stale = await fetchModelsDevCostMap(agentDir, true);
+		expect(toPiModel({ slug: "kimi-k3", context_window: 272_000, max_context_window: 272_000 }, stale)).toMatchObject(
+			{ contextWindow: 1_048_576, maxTokens: 65_536 },
+		);
+	});
+
+	it("writes resolved capabilities through the mapped-model cache round trip", async () => {
+		const agentDir = tempAgentDir();
+		vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+			if (String(input).includes("models.dev")) {
+				return response({
+					moonshotai: {
+						models: {
+							"kimi-k3": {
+								limit: { context: 1_048_576, output: 65_536 },
+								cost: { input: 3, output: 15 },
+							},
+						},
+					},
+				});
+			}
+			return new Response(
+				JSON.stringify({
+					models: [
+						{
+							slug: "kimi-k3",
+							display_name: "Kimi K3",
+							context_window: 272_000,
+							max_context_window: 272_000,
+						},
+					],
+				}),
+				{ status: 200 },
+			);
+		});
+
+		const loaded = await loadMappedModels("http://127.0.0.1:8317", "key", false, agentDir);
+		expect(loaded.models[0]).toMatchObject({ contextWindow: 1_048_576, maxTokens: 65_536 });
+
+		await resolveMappedModels(agentDir, "http://127.0.0.1:8317", "key", {
+			forceRefresh: true,
+			fastMode: false,
+		});
+		const cached = loadModelsCache(agentDir, "http://127.0.0.1:8317");
+		expect(cached?.models[0]).toMatchObject({ contextWindow: 1_048_576, maxTokens: 65_536 });
+	});
+});

--- a/test/codex-replay.test.ts
+++ b/test/codex-replay.test.ts
@@ -1,0 +1,199 @@
+import type { Api, AssistantMessage, Context, Model, ToolResultMessage } from "@earendil-works/pi-ai";
+import { describe, expect, it } from "vitest";
+import { loadCliproxyCodexStreams } from "../extensions/codex-stream.ts";
+
+const model: Model<Api> = {
+	id: "kimi-k3",
+	name: "Kimi K3",
+	api: "cliproxyapi-codex-responses",
+	provider: "cliproxyapi",
+	baseUrl: "http://127.0.0.1:8317/v1",
+	reasoning: true,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 256_000,
+	maxTokens: 32_000,
+};
+
+const usage = {
+	input: 1,
+	output: 1,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 2,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+function assistantToolCall(id: string, name: string, arguments_: Record<string, unknown>): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "toolCall", id, name, arguments: arguments_ }],
+		api: model.api,
+		provider: model.provider,
+		model: model.id,
+		usage,
+		stopReason: "toolUse",
+		timestamp: 1,
+	};
+}
+
+function toolResult(id: string, name: string, output: string): ToolResultMessage {
+	return {
+		role: "toolResult",
+		toolCallId: id,
+		toolName: name,
+		content: [{ type: "text", text: output }],
+		isError: false,
+		timestamp: 2,
+	};
+}
+
+async function capturePayload(context: Context): Promise<Record<string, unknown>> {
+	const streams = await loadCliproxyCodexStreams();
+	let captured: Record<string, unknown> | undefined;
+	const result = await streams
+		.streamSimple(model, context, {
+			apiKey: "test-key",
+			transport: "sse",
+			onPayload: (payload) => {
+				if (payload && typeof payload === "object" && !Array.isArray(payload)) {
+					captured = structuredClone(payload) as Record<string, unknown>;
+				}
+				throw new Error("payload captured");
+			},
+		})
+		.result();
+
+	expect(result.stopReason).toBe("error");
+	expect(captured).toBeDefined();
+	return captured as Record<string, unknown>;
+}
+
+function responsesInput(payload: Record<string, unknown>): Record<string, unknown>[] {
+	const input = payload.input;
+	expect(Array.isArray(input)).toBe(true);
+	return input as Record<string, unknown>[];
+}
+
+function toolItems(payload: Record<string, unknown>): Record<string, unknown>[] {
+	return responsesInput(payload).filter(
+		(item) => item.type === "function_call" || item.type === "function_call_output",
+	);
+}
+
+function expectUniquePairedToolIdentities(payload: Record<string, unknown>): void {
+	const calls = toolItems(payload).filter((item) => item.type === "function_call");
+	const outputs = toolItems(payload).filter((item) => item.type === "function_call_output");
+	const callIds = calls.map((item) => item.call_id);
+	const itemIds = calls.map((item) => item.id);
+
+	expect(new Set(callIds).size).toBe(callIds.length);
+	expect(new Set(itemIds).size).toBe(itemIds.length);
+	expect(outputs.map((item) => item.call_id)).toEqual(callIds);
+	for (const id of [...callIds, ...itemIds]) {
+		expect(id).toMatch(/^[a-zA-Z0-9_-]{1,64}$/);
+	}
+}
+
+describe("Codex Responses history replay", () => {
+	it("deterministically disambiguates two non-adjacent repeated tool identities", async () => {
+		const context: Context = {
+			messages: [
+				assistantToolCall("read_0|fc_read_0", "read", { path: "first.ts" }),
+				toolResult("read_0|fc_read_0", "read", "first output"),
+				{ role: "user", content: "continue", timestamp: 3 },
+				assistantToolCall("bash_0|fc_bash_0", "bash", { command: "pwd" }),
+				toolResult("bash_0|fc_bash_0", "bash", "first bash output"),
+				assistantToolCall("read_0|fc_read_0", "read", { path: "second.ts" }),
+				toolResult("read_0|fc_read_0", "read", "second output"),
+				assistantToolCall("bash_0|fc_bash_0", "bash", { command: "git status" }),
+				toolResult("bash_0|fc_bash_0", "bash", "second bash output"),
+			],
+		};
+
+		const firstAttempt = await capturePayload(context);
+		const retry = await capturePayload(context);
+
+		expectUniquePairedToolIdentities(firstAttempt);
+		expect(retry).toEqual(firstAttempt);
+		expect(
+			toolItems(firstAttempt)
+				.filter((item) => item.type === "function_call")
+				.map((item) => [item.call_id, item.id]),
+		).toEqual([
+			["read_0", "fc_read_0"],
+			["bash_0", "fc_bash_0"],
+			["read_0_pi_2", "fc_read_0_pi_2"],
+			["bash_0_pi_2", "fc_bash_0_pi_2"],
+		]);
+		expect(toolItems(firstAttempt)).toEqual([
+			expect.objectContaining({ type: "function_call", name: "read", arguments: '{"path":"first.ts"}' }),
+			expect.objectContaining({ type: "function_call_output", output: "first output" }),
+			expect.objectContaining({ type: "function_call", name: "bash", arguments: '{"command":"pwd"}' }),
+			expect.objectContaining({ type: "function_call_output", output: "first bash output" }),
+			expect.objectContaining({ type: "function_call", name: "read", arguments: '{"path":"second.ts"}' }),
+			expect.objectContaining({ type: "function_call_output", output: "second output" }),
+			expect.objectContaining({ type: "function_call", name: "bash", arguments: '{"command":"git status"}' }),
+			expect.objectContaining({ type: "function_call_output", output: "second bash output" }),
+		]);
+	});
+
+	it("keeps adjacent repeated calls paired with their synthetic and real outputs", async () => {
+		const context: Context = {
+			messages: [
+				assistantToolCall("edit_86|fc_edit_86", "edit", { path: "first.ts" }),
+				assistantToolCall("edit_86|fc_edit_86", "edit", { path: "second.ts" }),
+				toolResult("edit_86|fc_edit_86", "edit", "edited second.ts"),
+			],
+		};
+
+		const payload = await capturePayload(context);
+
+		expectUniquePairedToolIdentities(payload);
+		expect(toolItems(payload)).toEqual([
+			expect.objectContaining({ type: "function_call", name: "edit", arguments: '{"path":"first.ts"}' }),
+			expect.objectContaining({ type: "function_call_output", output: "No result provided" }),
+			expect.objectContaining({ type: "function_call", name: "edit", arguments: '{"path":"second.ts"}' }),
+			expect.objectContaining({ type: "function_call_output", output: "edited second.ts" }),
+		]);
+	});
+
+	it("pairs repeated identities within one assistant turn by call order", async () => {
+		const sameTurn = assistantToolCall("write_4|fc_write_4", "write", { path: "first.ts" });
+		sameTurn.content.push({
+			type: "toolCall",
+			id: "write_4|fc_write_4",
+			name: "write",
+			arguments: { path: "second.ts" },
+		});
+		const payload = await capturePayload({
+			messages: [
+				sameTurn,
+				toolResult("write_4|fc_write_4", "write", "wrote first.ts"),
+				toolResult("write_4|fc_write_4", "write", "wrote second.ts"),
+			],
+		});
+
+		expectUniquePairedToolIdentities(payload);
+		expect(toolItems(payload).map((item) => [item.type, item.call_id, item.output])).toEqual([
+			["function_call", "write_4", undefined],
+			["function_call", "write_4_pi_2", undefined],
+			["function_call_output", "write_4", "wrote first.ts"],
+			["function_call_output", "write_4_pi_2", "wrote second.ts"],
+		]);
+	});
+
+	it("does not change identities when the replay has no duplicates", async () => {
+		const payload = await capturePayload({
+			messages: [
+				assistantToolCall("read_7|fc_read_7", "read", { path: "only.ts" }),
+				toolResult("read_7|fc_read_7", "read", "only output"),
+			],
+		});
+
+		expect(toolItems(payload).map((item) => ({ type: item.type, id: item.id, call_id: item.call_id }))).toEqual([
+			{ type: "function_call", id: "fc_read_7", call_id: "read_7" },
+			{ type: "function_call_output", id: undefined, call_id: "read_7" },
+		]);
+	});
+});

--- a/test/fast.test.ts
+++ b/test/fast.test.ts
@@ -10,7 +10,7 @@ import {
 	patchCodexSource,
 	resolveCodexModuleFromNodeEntry,
 	withPriorityServiceTier,
-	wrapStreamSimpleForFast,
+	wrapCliproxyCodexStream,
 } from "../extensions/codex-stream.ts";
 import { FastModeController } from "../extensions/fast.ts";
 import { FastFooterController, formatFastModelStatus } from "../extensions/fast-footer.ts";
@@ -350,18 +350,20 @@ describe("Fast pricing mapping", () => {
 });
 
 describe("Fast stream wrapper", () => {
-	it("passes options through unchanged when Fast is not effective", () => {
+	it("preserves options and payloads when Fast is not effective", async () => {
 		let captured: SimpleStreamOptions | undefined;
 		const streamResult = {} as ReturnType<CliproxyCodexStreamSimple>;
 		const baseStream: CliproxyCodexStreamSimple = (_model, _context, options) => {
 			captured = options;
 			return streamResult;
 		};
-		const wrapped = wrapStreamSimpleForFast(baseStream, () => false);
+		const wrapped = wrapCliproxyCodexStream(baseStream, () => false);
 		const options: SimpleStreamOptions = { timeoutMs: 1234 };
 
 		expect(wrapped(model, { messages: [] }, options)).toBe(streamResult);
-		expect(captured).toBe(options);
+		expect(captured?.timeoutMs).toBe(1234);
+		const payload = { model: "gpt-5.4", input: [] };
+		expect(await captured?.onPayload?.(payload, model)).toBe(payload);
 	});
 
 	it("preserves stream options and composes the Fast payload hook when enabled", async () => {
@@ -372,7 +374,7 @@ describe("Fast stream wrapper", () => {
 			captured = options;
 			return streamResult;
 		};
-		const wrapped = wrapStreamSimpleForFast(baseStream, () => true);
+		const wrapped = wrapCliproxyCodexStream(baseStream, () => true);
 		const options: SimpleStreamOptions = {
 			timeoutMs: 1234,
 			onPayload: (payload) => {

--- a/test/list-models.test.ts
+++ b/test/list-models.test.ts
@@ -1,0 +1,97 @@
+import { execFile } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { promisify } from "node:util";
+import { expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+const CLI_PATH = resolve("node_modules/@earendil-works/pi-coding-agent/dist/bundle/cli.js");
+const EXTENSION_PATH = resolve("extensions/index.ts");
+
+it("makes a cache-miss catalog available to pi --list-models during startup", async () => {
+	const server = createServer((request, response) => {
+		if (
+			request.url === "/v1/models?client_version=pi" &&
+			request.headers.authorization === "Bearer list-models-key"
+		) {
+			response.writeHead(200, { "Content-Type": "application/json" });
+			response.end(
+				JSON.stringify({
+					models: [
+						{
+							slug: "list-native-model",
+							display_name: "List Native Model",
+							context_window: 64_000,
+							max_completion_tokens: 4096,
+							input_modalities: ["text"],
+						},
+					],
+				}),
+			);
+			return;
+		}
+		response.writeHead(404).end();
+	});
+	await new Promise<void>((resolveListen) => server.listen(0, "127.0.0.1", resolveListen));
+	const address = server.address();
+	if (!address || typeof address === "string") throw new Error("Unable to resolve test server address");
+
+	const agentDir = mkdtempSync(join(tmpdir(), "pi-cliproxy-list-models-"));
+	try {
+		writeFileSync(
+			join(agentDir, "cliproxyapi.json"),
+			JSON.stringify({ baseUrl: `http://127.0.0.1:${address.port}`, apiKey: "list-models-key" }),
+			"utf8",
+		);
+		mkdirSync(join(agentDir, "tmp"), { recursive: true });
+		writeFileSync(
+			join(agentDir, "tmp", "models-dev-cache.json"),
+			JSON.stringify({
+				timestamp: Date.now(),
+				providers: {
+					openai: {
+						models: {
+							"list-native-model": {
+								cost: { input: 1, output: 2 },
+								limit: { context: 64_000, output: 4096 },
+							},
+						},
+					},
+				},
+			}),
+			"utf8",
+		);
+
+		const env: NodeJS.ProcessEnv = {
+			...process.env,
+			PI_CODING_AGENT_DIR: agentDir,
+			PI_SKIP_VERSION_CHECK: "1",
+		};
+		for (const name of [
+			"CLIPROXYAPI_API_KEY",
+			"CLIPROXYAPI_BASE_URL",
+			"CLIPROXYAPI_FAST",
+			"CLIPROXYAPI_PROVIDER_ID",
+			"CLIPROXYAPI_PROVIDER_NAME",
+		]) {
+			delete env[name];
+		}
+
+		const { stdout } = await execFileAsync(
+			process.execPath,
+			[CLI_PATH, "--no-extensions", "-e", EXTENSION_PATH, "--list-models", "list-native"],
+			{ cwd: process.cwd(), env, timeout: 30_000 },
+		);
+		expect(stdout).toContain("cliproxyapi");
+		expect(stdout).toContain("list-native-model");
+		expect(stdout).toContain("64K");
+		expect(stdout).toContain("4.1K");
+	} finally {
+		await new Promise<void>((resolveClose, rejectClose) => {
+			server.close((error) => (error ? rejectClose(error) : resolveClose()));
+		});
+		rmSync(agentDir, { recursive: true, force: true });
+	}
+}, 45_000);

--- a/test/pi-compat.test.ts
+++ b/test/pi-compat.test.ts
@@ -1,8 +1,13 @@
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { Api, Model } from "@earendil-works/pi-ai";
-import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { Api, Model, RefreshModelsContext } from "@earendil-works/pi-ai";
+import type {
+	ExtensionAPI,
+	ExtensionCommandContext,
+	ExtensionContext,
+	ProviderConfig,
+} from "@earendil-works/pi-coding-agent";
 import { describe, expect, it, vi } from "vitest";
 import providerExtension from "../extensions/index.ts";
 import { AUTH_FILE_NAME } from "../extensions/lib.ts";
@@ -44,6 +49,21 @@ async function withTempAgentDir(run: (agentDir: string) => Promise<void>): Promi
 function createPiMock(commands: Map<string, Parameters<ExtensionAPI["registerCommand"]>[1]>) {
 	const handlers = new Map<string, Array<(event: unknown, ctx: ExtensionContext) => unknown>>();
 	const registeredModels = new Map<string, Model<Api>>();
+	let providerConfig: ProviderConfig | undefined;
+	let refreshController: AbortController | undefined;
+	const installModels = (providerId: string, config: ProviderConfig, models = config.models ?? []): void => {
+		for (const key of registeredModels.keys()) {
+			if (key.startsWith(`${providerId}/`)) registeredModels.delete(key);
+		}
+		for (const model of models) {
+			registeredModels.set(`${providerId}/${model.id}`, {
+				...model,
+				provider: providerId,
+				api: config.api as Api,
+				baseUrl: config.baseUrl as string,
+			});
+		}
+	};
 	const pi = {
 		registerCommand: vi.fn((name: string, options: Parameters<ExtensionAPI["registerCommand"]>[1]) => {
 			commands.set(name, options);
@@ -53,17 +73,9 @@ function createPiMock(commands: Map<string, Parameters<ExtensionAPI["registerCom
 				if (key.startsWith(`${providerId}/`)) registeredModels.delete(key);
 			}
 		}),
-		registerProvider: vi.fn((providerId: string, config: Record<string, unknown>) => {
-			const models = Array.isArray(config.models) ? config.models : [];
-			for (const model of models) {
-				const entry = model as Model<Api>;
-				registeredModels.set(`${providerId}/${entry.id}`, {
-					...entry,
-					provider: providerId,
-					api: config.api as Api,
-					baseUrl: config.baseUrl as string,
-				});
-			}
+		registerProvider: vi.fn((providerId: string, config: ProviderConfig) => {
+			providerConfig = config;
+			installModels(providerId, config);
 		}),
 		setModel: vi.fn(async () => true),
 		on: vi.fn((event: string, handler: (event: unknown, ctx: ExtensionContext) => unknown) => {
@@ -71,16 +83,53 @@ function createPiMock(commands: Map<string, Parameters<ExtensionAPI["registerCom
 		}),
 	} as unknown as ExtensionAPI;
 	const modelRegistry = {
+		refresh: vi.fn(async (options: { force?: boolean } = {}) => {
+			refreshController?.abort();
+			const controller = new AbortController();
+			refreshController = controller;
+			const errors = new Map<string, Error>();
+			const callback = providerConfig?.refreshModels;
+			if (callback && providerConfig) {
+				const run = async (allowNetwork: boolean): Promise<void> => {
+					const context: RefreshModelsContext = {
+						allowNetwork,
+						...(allowNetwork && options.force ? { force: true } : {}),
+						signal: controller.signal,
+						publish: async ({ update }) => {
+							if (controller.signal.aborted) return false;
+							update?.();
+							return true;
+						},
+					};
+					const models = await callback(context);
+					if (!controller.signal.aborted && providerConfig) {
+						providerConfig.models = models;
+						installModels("cliproxyapi", providerConfig, models);
+					}
+				};
+				try {
+					await run(false);
+					if (!controller.signal.aborted) await run(true);
+				} catch (error) {
+					if (!controller.signal.aborted) {
+						errors.set("cliproxyapi", error instanceof Error ? error : new Error(String(error)));
+					}
+				}
+			}
+			return { aborted: controller.signal.aborted, errors };
+		}),
 		find: (providerId: string, modelId: string) => registeredModels.get(`${providerId}/${modelId}`),
+		getProvider: (providerId: string) =>
+			providerId === "cliproxyapi" ? { getModels: () => [...registeredModels.values()] } : undefined,
 	};
-	return { pi, handlers, modelRegistry, registeredModels };
+	return { pi, handlers, modelRegistry, registeredModels, getProviderConfig: () => providerConfig };
 }
 
-describe("pi 0.82.0 compatibility", () => {
+describe("pi 0.84.3 native model refresh compatibility", () => {
 	it("registers oauth login and /fast without a dedicated /cliproxyapi command", async () => {
 		await withTempAgentDir(async () => {
 			const commands = new Map<string, Parameters<ExtensionAPI["registerCommand"]>[1]>();
-			const { pi } = createPiMock(commands);
+			const { pi, getProviderConfig } = createPiMock(commands);
 			const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
 				new Response(JSON.stringify({ models: [] }), {
 					status: 200,
@@ -98,18 +147,59 @@ describe("pi 0.82.0 compatibility", () => {
 				expect(commands.has("continue")).toBe(true);
 				expect(commands.has("cliproxyapi-refresh")).toBe(true);
 				expect(commands.has("cliproxyapi")).toBe(false);
-				expect(pi.unregisterProvider).toHaveBeenCalledWith("cliproxyapi");
+				expect(pi.unregisterProvider).not.toHaveBeenCalled();
+				expect(pi.registerProvider).toHaveBeenCalledTimes(1);
 				expect(pi.registerProvider).toHaveBeenCalledWith(
 					"cliproxyapi",
 					expect.objectContaining({
 						name: "CLIProxyAPI",
 						oauth: expect.any(Object),
+						refreshModels: expect.any(Function),
 					}),
 				);
+				expect(getProviderConfig()?.refreshModels).toBeTypeOf("function");
 				// OAuth-only registration keeps `/login cliproxyapi` off the API-key selector.
 				for (const [, config] of (pi.registerProvider as ReturnType<typeof vi.fn>).mock.calls) {
 					expect(config).not.toHaveProperty("apiKey");
 				}
+			} finally {
+				fetchMock.mockRestore();
+			}
+		});
+	});
+
+	it("keeps /login on the OAuth multi-field flow and refreshes without re-registering", async () => {
+		await withTempAgentDir(async () => {
+			const commands = new Map<string, Parameters<ExtensionAPI["registerCommand"]>[1]>();
+			const { pi, getProviderConfig } = createPiMock(commands);
+			const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+				if (String(input).startsWith("https://models.dev/")) {
+					return new Response("{}", { status: 200 });
+				}
+				return new Response(JSON.stringify({ models: [{ slug: "login-refreshed" }] }), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				});
+			});
+
+			try {
+				await providerExtension(pi);
+				const oauth = getProviderConfig()?.oauth;
+				if (!oauth) throw new Error("OAuth provider was not registered");
+				const onPrompt = vi.fn().mockResolvedValueOnce("http://127.0.0.1:8317").mockResolvedValueOnce("login-key");
+				const credential = await oauth.login({
+					onAuth: vi.fn(),
+					onDeviceCode: vi.fn(),
+					onPrompt,
+					onProgress: vi.fn(),
+					onSelect: vi.fn(),
+				});
+
+				expect(onPrompt).toHaveBeenCalledTimes(2);
+				expect(credential.access).toBe("login-key");
+				expect(getProviderConfig()?.models?.map((model) => model.id)).toEqual(["login-refreshed"]);
+				expect(pi.registerProvider).toHaveBeenCalledTimes(1);
+				expect(pi.unregisterProvider).not.toHaveBeenCalled();
 			} finally {
 				fetchMock.mockRestore();
 			}
@@ -185,6 +275,8 @@ describe("pi 0.82.0 compatibility", () => {
 						cost: { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 6.25 },
 					}),
 				);
+				expect(pi.registerProvider).toHaveBeenCalledTimes(1);
+				expect(pi.unregisterProvider).not.toHaveBeenCalled();
 			} finally {
 				fetchMock.mockRestore();
 			}


### PR DESCRIPTION
## Summary

- resolve dynamic model context windows and max output tokens from the canonical models.dev catalog
- preserve explicit non-template capabilities returned by CLIProxyAPI
- keep intentional 272K GPT-5.6 pricing-tier contexts while correcting models such as Kimi K3
- fail closed to conservative defaults for unknown models and reuse stale catalog data when refreshes fail
- persist the resolved capabilities in the existing model cache

## Resolution priority

1. explicit non-template CLIProxyAPI capability
2. exact canonical model ID or known alias from models.dev
3. conservative provider defaults

Matching is exact/alias-based only; no fuzzy model-name guessing or user-maintained per-model override table is introduced.

## Verification

- `npm run check`
- TypeScript typecheck and Biome checks pass
- 9 test files / 105 tests pass
- live read-only verification against a local CLIProxyAPI catalog:
  - `kimi-k3`: context `1,048,576`, max output `65,536`
  - GPT-5.6 short-context tier remains `272,000`
