### PR TITLE
fix: treat ctx.isProjectTrusted as optional

### DIFF
--- a/extensions/auto-compact.ts
+++ b/extensions/auto-compact.ts
@@ -76,7 +76,8 @@ export class ProactiveCompactionController {
 	register(pi: ExtensionAPI): void {
 		pi.on("session_start", (_event, ctx) => {
 			this.settingsManager = SettingsManager.create(ctx.cwd, this.agentDir, {
-				projectTrusted: ctx.isProjectTrusted(),
+				projectTrusted:
+					typeof ctx.isProjectTrusted === "function" ? ctx.isProjectTrusted() : true,
 			});
 			this.pending = undefined;
 		});

--- a/test/auto-compact.test.ts
+++ b/test/auto-compact.test.ts
@@ -158,4 +158,22 @@ describe("proactive compaction controller", () => {
 		await handlers.get("turn_end")?.({ message, toolResults: [{}] }, ctx);
 		expect(wrapped(model, { messages: [] })).toBe(baseResult);
 	});
+
+	it("does not throw when ctx.isProjectTrusted is missing", () => {
+		const agentDir = mkdtempSync(join(tmpdir(), "pi-cliproxyapi-auto-compact-agent-"));
+		const cwd = mkdtempSync(join(tmpdir(), "pi-cliproxyapi-auto-compact-cwd-"));
+		tempDirs.push(agentDir, cwd);
+		const handlers = new Map<string, (event: any, ctx: ExtensionContext) => unknown>();
+		const pi = {
+			on: (event: string, handler: (event: any, ctx: ExtensionContext) => unknown) => handlers.set(event, handler),
+		} as unknown as ExtensionAPI;
+		const controller = new ProactiveCompactionController(agentDir, "cliproxyapi");
+		controller.register(pi);
+		const ctx = {
+			cwd,
+			model: { id: "gpt-5.6-sol", provider: "cliproxyapi", api: "openai-codex-responses", contextWindow: CONTEXT_WINDOW },
+			getContextUsage: () => ({ tokens: 1, contextWindow: CONTEXT_WINDOW, percent: 1 }),
+		} as unknown as ExtensionContext;
+		expect(() => handlers.get("session_start")?.({}, ctx)).not.toThrow();
+	});
 });


### PR DESCRIPTION
Treat `ctx.isProjectTrusted` as optional so compiled/bundled hosts do not crash the extension.

Fixes #14 (the `isProjectTrusted is not a function` half; module resolve remains #19)

## Why
On compiled Pi/OMP hosts the extension context may omit `isProjectTrusted`. Calling it throws TypeError and can prevent provider registration.

## Changes
- Call `isProjectTrusted` only when `typeof === "function"`
- Default `projectTrusted: true` when the method is absent
- Regression test

## Test
`vitest run test/auto-compact.test.ts` (8 pass)
