### PR TITLE
feat: prefer gateway tokens_per_second in TPS status

### DIFF
--- a/extensions/gateway-telemetry.ts
+++ b/extensions/gateway-telemetry.ts
@@ -1,20 +1,35 @@
-export function tokensPerSecondFromUsage(usage: unknown): number | undefined {
-	if (!usage || typeof usage !== "object") return undefined;
-	const record = usage as Record<string, unknown>;
-	const raw = record.tokens_per_second ?? record.tokensPerSecond;
-	if (typeof raw === "number" && Number.isFinite(raw) && raw > 0) return raw;
-	if (typeof raw === "string" && raw.trim() !== "") {
-		const parsed = Number(raw);
-		if (Number.isFinite(parsed) && parsed > 0) return parsed;
-	}
-	return undefined;
+function readPositiveNumber(raw: string | null): number | undefined {
+	if (raw == null || raw.trim() === "") return undefined;
+	const parsed = Number(raw);
+	if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
+	return parsed;
 }
 
-/** Gateway tok/s only. Never invent tokens / elapsed (includes TTFT/tool pauses). */
-export function formatGatewayTokensPerSecond(usages: unknown[]): string {
-	for (const usage of usages) {
-		const tps = tokensPerSecondFromUsage(usage);
-		if (tps !== undefined) return tps.toFixed(1);
-	}
-	return "--";
+/** Gateway tok/s from inference response headers. Never tokens/latency. */
+export function tokensPerSecondFromHeaders(headers: Headers): number | undefined {
+	return readPositiveNumber(
+		headers.get("x-cliproxyapi-tokens-per-second") ??
+			headers.get("x-cliproxy-tokens-per-second") ??
+			headers.get("x-omniroute-tokens-per-second"),
+	);
+}
+
+export function captureGatewayTokensPerSecond(response: Response): number | undefined {
+	return tokensPerSecondFromHeaders(response.headers);
+}
+
+export function wrapFetchCaptureTokensPerSecond(
+	fetchImpl: typeof fetch,
+	onCapture: (tps: number) => void,
+): typeof fetch {
+	return async (input, init) => {
+		const response = await fetchImpl(input, init);
+		const tps = captureGatewayTokensPerSecond(response);
+		if (tps !== undefined) onCapture(tps);
+		return response;
+	};
+}
+
+export function formatGatewayTokensPerSecond(tps: number | undefined): string {
+	return tps === undefined ? "--" : tps.toFixed(1);
 }

--- a/extensions/gateway-telemetry.ts
+++ b/extensions/gateway-telemetry.ts
@@ -1,0 +1,20 @@
+export function tokensPerSecondFromUsage(usage: unknown): number | undefined {
+	if (!usage || typeof usage !== "object") return undefined;
+	const record = usage as Record<string, unknown>;
+	const raw = record.tokens_per_second ?? record.tokensPerSecond;
+	if (typeof raw === "number" && Number.isFinite(raw) && raw > 0) return raw;
+	if (typeof raw === "string" && raw.trim() !== "") {
+		const parsed = Number(raw);
+		if (Number.isFinite(parsed) && parsed > 0) return parsed;
+	}
+	return undefined;
+}
+
+/** Gateway tok/s only. Never invent tokens / elapsed (includes TTFT/tool pauses). */
+export function formatGatewayTokensPerSecond(usages: unknown[]): string {
+	for (const usage of usages) {
+		const tps = tokensPerSecondFromUsage(usage);
+		if (tps !== undefined) return tps.toFixed(1);
+	}
+	return "--";
+}

--- a/extensions/tps.ts
+++ b/extensions/tps.ts
@@ -124,8 +124,10 @@ export default function (pi: ExtensionAPI) {
 		totalTokens = 0;
 		capturedTokensPerSecond = undefined;
 		if (!restoreFetch) {
-			const originalFetch = globalThis.fetch.bind(globalThis);
-			globalThis.fetch = wrapFetchCaptureTokensPerSecond(originalFetch, (tpsValue) => {
+			const originalFetch = globalThis.fetch;
+			globalThis.fetch = wrapFetchCaptureTokensPerSecond((input, init) => {
+				return originalFetch.call(globalThis, input, init);
+			}, (tpsValue) => {
 				capturedTokensPerSecond = tpsValue;
 			});
 			restoreFetch = () => {

--- a/extensions/tps.ts
+++ b/extensions/tps.ts
@@ -1,6 +1,7 @@
 import type { AssistantMessage } from "@earendil-works/pi-ai";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { pauseController } from "./pause.ts";
+import { formatGatewayTokensPerSecond, tokensPerSecondFromUsage } from "./gateway-telemetry.ts";
 
 const STATUS_KEY = "tps";
 const REFRESH_INTERVAL_MS = 1000;
@@ -32,6 +33,7 @@ export default function (pi: ExtensionAPI) {
 	let cacheRead = 0;
 	let cacheWrite = 0;
 	let totalTokens = 0;
+	const gatewayUsages: unknown[] = [];
 
 	function clearRefreshTimer(): void {
 		if (refreshTimer === undefined) return;
@@ -119,6 +121,7 @@ export default function (pi: ExtensionAPI) {
 		cacheRead = 0;
 		cacheWrite = 0;
 		totalTokens = 0;
+		gatewayUsages.length = 0;
 		refreshStatus();
 
 		clearRefreshTimer();
@@ -137,6 +140,9 @@ export default function (pi: ExtensionAPI) {
 			cacheRead += message.usage.cacheRead || 0;
 			cacheWrite += message.usage.cacheWrite || 0;
 			totalTokens += message.usage.totalTokens || 0;
+			if (tokensPerSecondFromUsage(message.usage) !== undefined) {
+				gatewayUsages.push(message.usage);
+			}
 		}
 	});
 
@@ -158,7 +164,7 @@ export default function (pi: ExtensionAPI) {
 
 		if (elapsedMs <= 0) return;
 
-		const tps = output > 0 ? (output / elapsedSecondsExact).toFixed(1) : "--";
+		const tps = formatGatewayTokensPerSecond(gatewayUsages);
 		const message = `TPS ${tps} tok/s. out ${output.toLocaleString()}, in ${input.toLocaleString()}, cache r/w ${cacheRead.toLocaleString()}/${cacheWrite.toLocaleString()}, total ${totalTokens.toLocaleString()}, ${elapsedSecondsExact.toFixed(1)}s`;
 		ctx.ui.notify(message, "info");
 	});

--- a/extensions/tps.ts
+++ b/extensions/tps.ts
@@ -1,7 +1,7 @@
 import type { AssistantMessage } from "@earendil-works/pi-ai";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { pauseController } from "./pause.ts";
-import { formatGatewayTokensPerSecond, tokensPerSecondFromUsage } from "./gateway-telemetry.ts";
+import { formatGatewayTokensPerSecond, wrapFetchCaptureTokensPerSecond } from "./gateway-telemetry.ts";
 
 const STATUS_KEY = "tps";
 const REFRESH_INTERVAL_MS = 1000;
@@ -33,7 +33,8 @@ export default function (pi: ExtensionAPI) {
 	let cacheRead = 0;
 	let cacheWrite = 0;
 	let totalTokens = 0;
-	const gatewayUsages: unknown[] = [];
+	let capturedTokensPerSecond: number | undefined;
+	let restoreFetch: (() => void) | undefined;
 
 	function clearRefreshTimer(): void {
 		if (refreshTimer === undefined) return;
@@ -121,7 +122,16 @@ export default function (pi: ExtensionAPI) {
 		cacheRead = 0;
 		cacheWrite = 0;
 		totalTokens = 0;
-		gatewayUsages.length = 0;
+		capturedTokensPerSecond = undefined;
+		if (!restoreFetch) {
+			const originalFetch = globalThis.fetch.bind(globalThis);
+			globalThis.fetch = wrapFetchCaptureTokensPerSecond(originalFetch, (tpsValue) => {
+				capturedTokensPerSecond = tpsValue;
+			});
+			restoreFetch = () => {
+				globalThis.fetch = originalFetch;
+			};
+		}
 		refreshStatus();
 
 		clearRefreshTimer();
@@ -140,9 +150,6 @@ export default function (pi: ExtensionAPI) {
 			cacheRead += message.usage.cacheRead || 0;
 			cacheWrite += message.usage.cacheWrite || 0;
 			totalTokens += message.usage.totalTokens || 0;
-			if (tokensPerSecondFromUsage(message.usage) !== undefined) {
-				gatewayUsages.push(message.usage);
-			}
 		}
 	});
 
@@ -162,9 +169,10 @@ export default function (pi: ExtensionAPI) {
 		setElapsedStatus(ctx, elapsedSecondsFloor);
 		statusCtx = ctx;
 
+		const tps = formatGatewayTokensPerSecond(capturedTokensPerSecond);
+		restoreFetch?.();
+		restoreFetch = undefined;
 		if (elapsedMs <= 0) return;
-
-		const tps = formatGatewayTokensPerSecond(gatewayUsages);
 		const message = `TPS ${tps} tok/s. out ${output.toLocaleString()}, in ${input.toLocaleString()}, cache r/w ${cacheRead.toLocaleString()}/${cacheWrite.toLocaleString()}, total ${totalTokens.toLocaleString()}, ${elapsedSecondsExact.toFixed(1)}s`;
 		ctx.ui.notify(message, "info");
 	});
@@ -176,5 +184,8 @@ export default function (pi: ExtensionAPI) {
 		pausedDurationAtStartMs = 0;
 		pauseWasEnabledAtStart = false;
 		statusCtx = null;
+		restoreFetch?.();
+		restoreFetch = undefined;
+		capturedTokensPerSecond = undefined;
 	});
 }

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -79,6 +79,18 @@ async function waitForAsyncRefresh(): Promise<void> {
 	}
 }
 
+async function waitForMockCalls(
+	mock: { mock: { calls: unknown[] } },
+	count: number,
+	timeoutMs = 3000,
+): Promise<void> {
+	const started = Date.now();
+	while (mock.mock.calls.length < count) {
+		if (Date.now() - started >= timeoutMs) return;
+		await new Promise<void>((resolve) => setTimeout(resolve, 10));
+	}
+}
+
 async function withTempAgentDir(run: (agentDir: string) => Promise<void>): Promise<void> {
 	const agentDir = tempAgentDir();
 	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
@@ -350,7 +362,7 @@ describe("provider startup cache behavior", () => {
 
 			try {
 				const startup = providerExtension(pi);
-				await waitForAsyncRefresh();
+				await waitForMockCalls(fetchMock, 2);
 				expect(fetchMock).toHaveBeenCalledTimes(2);
 				releaseRemote(
 					new Response(JSON.stringify({ models: [createCodexModel("startup-remote")] }), { status: 200 }),

--- a/test/gateway-telemetry.test.ts
+++ b/test/gateway-telemetry.test.ts
@@ -1,14 +1,46 @@
 import { describe, expect, it } from "vitest";
-import { formatGatewayTokensPerSecond, tokensPerSecondFromUsage } from "../extensions/gateway-telemetry.ts";
+import {
+	captureGatewayTokensPerSecond,
+	formatGatewayTokensPerSecond,
+	tokensPerSecondFromHeaders,
+	wrapFetchCaptureTokensPerSecond,
+} from "../extensions/gateway-telemetry.ts";
 
-describe("gateway tok/s", () => {
-	it("prefers usage.tokens_per_second", () => {
-		expect(tokensPerSecondFromUsage({ tokens_per_second: 80.5, output: 200 })).toBe(80.5);
-		expect(formatGatewayTokensPerSecond([{ output: 10 }, { tokens_per_second: 40 }])).toBe("40.0");
+describe("gateway tok/s from Response headers", () => {
+	it("reads X-CLIProxyAPI-Tokens-Per-Second off a real Response", async () => {
+		const inner: typeof fetch = async () =>
+			new Response("{}", {
+				headers: { "X-CLIProxyAPI-Tokens-Per-Second": "80.5", "X-OmniRoute-Latency-Ms": "2000" },
+			});
+		let captured: number | undefined;
+		const wrapped = wrapFetchCaptureTokensPerSecond(inner, (tps) => {
+			captured = tps;
+		});
+		const response = await wrapped("https://gateway.example/v1/chat/completions");
+		expect(captureGatewayTokensPerSecond(response)).toBe(80.5);
+		expect(captured).toBe(80.5);
+		expect(formatGatewayTokensPerSecond(captured)).toBe("80.5");
 	});
 
-	it("does not invent tok/s from output / elapsed", () => {
-		expect(tokensPerSecondFromUsage({ output: 200, latency_ms: 2000 })).toBeUndefined();
-		expect(formatGatewayTokensPerSecond([{ output: 200 }])).toBe("--");
+	it("does not invent tok/s from latency or output headers", async () => {
+		const inner: typeof fetch = async () =>
+			new Response("{}", {
+				headers: {
+					"X-OmniRoute-Latency-Ms": "2000",
+					"X-OmniRoute-Tokens-Out": "200",
+				},
+			});
+		let captured: number | undefined;
+		const wrapped = wrapFetchCaptureTokensPerSecond(inner, (tps) => {
+			captured = tps;
+		});
+		await wrapped("https://gateway.example/v1/chat/completions");
+		expect(captured).toBeUndefined();
+		expect(
+			tokensPerSecondFromHeaders(
+				new Headers({ "X-OmniRoute-Latency-Ms": "2000", "X-OmniRoute-Tokens-Out": "200" }),
+			),
+		).toBeUndefined();
+		expect(formatGatewayTokensPerSecond(undefined)).toBe("--");
 	});
 });

--- a/test/gateway-telemetry.test.ts
+++ b/test/gateway-telemetry.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { formatGatewayTokensPerSecond, tokensPerSecondFromUsage } from "../extensions/gateway-telemetry.ts";
+
+describe("gateway tok/s", () => {
+	it("prefers usage.tokens_per_second", () => {
+		expect(tokensPerSecondFromUsage({ tokens_per_second: 80.5, output: 200 })).toBe(80.5);
+		expect(formatGatewayTokensPerSecond([{ output: 10 }, { tokens_per_second: 40 }])).toBe("40.0");
+	});
+
+	it("does not invent tok/s from output / elapsed", () => {
+		expect(tokensPerSecondFromUsage({ output: 200, latency_ms: 2000 })).toBeUndefined();
+		expect(formatGatewayTokensPerSecond([{ output: 200 }])).toBe("--");
+	});
+});


### PR DESCRIPTION
Capture gateway tok/s from inference Response headers (`X-CLIProxyAPI-Tokens-Per-Second`, `X-CLIProxy-Tokens-Per-Second`, `X-OmniRoute-Tokens-Per-Second`).

Pi `message.usage` does not include `tokens_per_second`. Do not invent tok/s from latency or `output / elapsed`. If the gateway did not send tok/s, show `--`.

`npx vitest run test/gateway-telemetry.test.ts`

Closes #24
