### PR TITLE
fix: restore SSE fallback for Azure-mapped CPA models

### DIFF
--- a/extensions/codex-stream.ts
+++ b/extensions/codex-stream.ts
@@ -99,65 +99,29 @@ function rewriteRelativeImports(source: string, originalDir: string): string {
 	});
 }
 
-function patchWebSocketOnlyTransport(source: string): string {
+function patchCodexTransportForCliproxy(source: string): string {
 	const sessionIdExpression = String.raw`(?:options\?\.sessionId|cacheSessionId)`;
 	const disabledForSession = new RegExp(
 		String.raw`const websocketDisabledForSession\s*=\s*transport !== "sse" && isWebSocketSseFallbackActive\(${sessionIdExpression}\);`,
 	);
-	const retryVariables = /let retriedWebSocketConnectionLimit\s*=\s*false;/;
-	const connectionLimitRetry =
-		/if \(!aborted && connectionLimitBeforeStart && !retriedWebSocketConnectionLimit\) \{\s*retriedWebSocketConnectionLimit = true;\s*continue;\s*\}/;
-	const websocketFailureHandling = new RegExp(
-		String.raw`if \(aborted \|\| \(isCodexNonTransportError\(error\) && !connectionLimitBeforeStart\)\) \{[\s\S]*?recordWebSocketFailure\((${sessionIdExpression}), error\);[\s\S]*?recordWebSocketSseFallback\(\1\);\s*break;`,
-	);
-	const fallbackSessionRecord = "websocketSseFallbackSessions.add(sessionId);";
-	const fallbackActiveRecord = "stats.websocketFallbackActive = true;";
+	const startedThrow = /if \(websocketStarted\) \{\s*throw error;\s*\}/;
 
-	for (const fragment of [fallbackSessionRecord, fallbackActiveRecord]) {
-		if (!source.includes(fragment)) {
-			throw new Error("openai-codex-responses source no longer supports the WebSocket-only transport patch");
-		}
-	}
-	for (const pattern of [disabledForSession, retryVariables, connectionLimitRetry, websocketFailureHandling]) {
-		if (!pattern.test(source)) {
-			throw new Error("openai-codex-responses source no longer supports the WebSocket-only transport patch");
-		}
+	if (!disabledForSession.test(source) || !startedThrow.test(source)) {
+		throw new Error("openai-codex-responses source no longer supports the CLIProxyAPI SSE fallback patch");
 	}
 
 	return source
-		.replace(disabledForSession, "const websocketDisabledForSession = false;")
 		.replace(
-			retryVariables,
-			`let websocketRetries = 0;
-                const maxWebSocketRetries = Number.isFinite(options?.maxRetries)
-                    ? Math.min(Math.max(0, Math.floor(options.maxRetries)), 5)
-                    : 3;`,
+			disabledForSession,
+			'const websocketDisabledForSession = transport !== "sse" && (isWebSocketSseFallbackActive(cacheSessionId) || !accountId);',
 		)
-		.replace(connectionLimitRetry, "")
 		.replace(
-			websocketFailureHandling,
-			(
-				_match,
-				activeSessionId: string,
-			) => `if (aborted || (isCodexNonTransportError(error) && !connectionLimitBeforeStart)) {
+			startedThrow,
+			`if (websocketStarted) {
+                            recordWebSocketSseFallback(cacheSessionId);
                             throw error;
-                        }
-                        if (!websocketStarted && websocketRetries < maxWebSocketRetries) {
-                            websocketRetries++;
-                            continue;
-                        }
-                        appendAssistantMessageDiagnostic(output, createAssistantMessageDiagnostic("provider_transport_failure", error, {
-                            configuredTransport: transport,
-                            fallbackTransport: undefined,
-                            eventsEmitted: websocketStarted,
-                            phase: websocketStarted ? "after_message_stream_start" : "before_message_stream_start",
-                            requestBytes: new TextEncoder().encode(bodyJson).byteLength,
-                        }));
-                        recordWebSocketFailure(${activeSessionId}, error);
-                        throw error;`,
-		)
-		.replace(fallbackSessionRecord, "")
-		.replace(fallbackActiveRecord, "stats.websocketFallbackActive = false;");
+                        }`,
+		);
 }
 
 export function patchCodexSource(source: string, providerIds: string[]): string {
@@ -193,9 +157,10 @@ export function patchCodexSource(source: string, providerIds: string[]): string 
 	// Keep assistant message api metadata aligned with the registered custom api id.
 	src = src.replaceAll(`api: "openai-codex-responses"`, `api: ${JSON.stringify(CLIPROXYAPI_CODEX_API)}`);
 
-	// CLIProxyAPI needs a persistent WebSocket transport. Reconnect before the
-	// response starts and surface a failure rather than silently switching to SSE.
-	src = patchWebSocketOnlyTransport(src);
+	// Plain CPA keys have no ChatGPT account id. Prefer SSE for those models, and
+	// record SSE fallback after a mid-stream WebSocket failure so the next attempt
+	// does not retry the same Azure 502 as a generic WebSocket error.
+	src = patchCodexTransportForCliproxy(src);
 
 	// The generated module lives outside the original source map directory.
 	src = src.replace(/^\/\/# sourceMappingURL=.*$/gm, "");

--- a/extensions/retry.ts
+++ b/extensions/retry.ts
@@ -4,6 +4,22 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 const TRANSIENT_STREAM_ERROR_PATTERN =
 	/\bclosed network connection\b|\bstream disconnected before completion: stream closed before response\.completed\b|\binvalid SSE data JSON\b/i;
 const NETWORK_ERROR_PREFIX = "network error:";
+const CAPACITY_ERROR_PATTERN = /maximum usage size allowed during peak load|\bno healthy upstream\b/i;
+const CAPACITY_ERROR_PREFIX = "capacity error:";
+
+export function normalizeCapacityError(message: AssistantMessage): AssistantMessage {
+	if (message.stopReason !== "error" || !message.errorMessage) {
+		return message;
+	}
+	if (message.errorMessage.startsWith(CAPACITY_ERROR_PREFIX) || !CAPACITY_ERROR_PATTERN.test(message.errorMessage)) {
+		return message;
+	}
+
+	return {
+		...message,
+		errorMessage: `${CAPACITY_ERROR_PREFIX} ${message.errorMessage}`,
+	};
+}
 
 export function normalizeTransientNetworkError(message: AssistantMessage): AssistantMessage {
 	if (message.stopReason !== "error" || !message.errorMessage) {
@@ -26,7 +42,7 @@ export function registerTransientNetworkErrorRetry(pi: ExtensionAPI, providerId:
 			return;
 		}
 
-		const normalized = normalizeTransientNetworkError(message);
+		const normalized = normalizeTransientNetworkError(normalizeCapacityError(message));
 		if (normalized === message) {
 			return;
 		}

--- a/test/fast.test.ts
+++ b/test/fast.test.ts
@@ -53,25 +53,27 @@ describe("Codex protocol module resolution", () => {
 });
 
 describe("Codex WebSocket transport patch", () => {
-	it("reconnects WebSocket instead of falling back to SSE", () => {
+	it("falls back to SSE for plain CPA keys and after a WebSocket failure", () => {
 		const source = readFileSync(
 			new URL("../node_modules/@earendil-works/pi-ai/dist/api/openai-codex-responses.js", import.meta.url),
 			"utf8",
 		);
 		const patched = patchCodexSource(source, ["cliproxyapi"]);
 
-		expect(patched).toContain("const websocketDisabledForSession = false;");
-		expect(patched).toContain("let websocketRetries = 0;");
+		expect(patched).toContain("isWebSocketSseFallbackActive(cacheSessionId) || !accountId");
+		expect(patched).not.toContain("const websocketDisabledForSession = false;");
+		expect(patched).toContain('fallbackTransport: websocketStarted ? undefined : "sse"');
+		expect(patched).toContain("websocketSseFallbackSessions.add(sessionId);");
+		expect(patched).toMatch(/recordWebSocketSseFallback\([^)]*\);\s*break;/);
+		expect(patched).toMatch(
+			/if \(websocketStarted\) \{\s*recordWebSocketSseFallback\(cacheSessionId\);\s*throw error;/,
+		);
 		expect(patched).toContain("const connectionLimitBeforeStart = !websocketStarted");
 		expect(patched).toContain("isCodexNonTransportError(error) && !connectionLimitBeforeStart");
 		expect(patched).toContain("const previousResponseNotFound = isPreviousResponseNotFoundError(error);");
 		expect(patched).toContain("recordWebSocketFailure(cacheSessionId, error);");
-		expect(patched).toContain("const maxWebSocketRetries = Number.isFinite(options?.maxRetries)");
-		expect(patched).toContain("? Math.min(Math.max(0, Math.floor(options.maxRetries)), 5)");
-		expect(patched).toContain(": 3;");
-		expect(patched).not.toContain('fallbackTransport: websocketStarted ? undefined : "sse",');
-		expect(patched).not.toContain("websocketSseFallbackSessions.add(sessionId);");
-		expect(patched).not.toMatch(/recordWebSocketSseFallback\([^)]*\);\s*break;/);
+		expect(patched).not.toContain("let websocketRetries = 0;");
+		expect(patched).not.toContain("fallbackTransport: undefined");
 	});
 });
 

--- a/test/retry.test.ts
+++ b/test/retry.test.ts
@@ -1,7 +1,11 @@
 import { type AssistantMessage, isRetryableAssistantError } from "@earendil-works/pi-ai";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { describe, expect, it } from "vitest";
-import { normalizeTransientNetworkError, registerTransientNetworkErrorRetry } from "../extensions/retry.ts";
+import {
+	normalizeCapacityError,
+	normalizeTransientNetworkError,
+	registerTransientNetworkErrorRetry,
+} from "../extensions/retry.ts";
 
 const TRANSIENT_STREAM_ERRORS = [
 	"Codex error: read tcp 172.16.209.2:57303->172.64.155.209:443: use of closed network connection",
@@ -48,6 +52,31 @@ describe("transient network error normalization", () => {
 		expect(normalizeTransientNetworkError(retryable)).toBe(retryable);
 		expect(normalizeTransientNetworkError(unrelated)).toBe(unrelated);
 	});
+});
+
+const CAPACITY_ERRORS = [
+	"The system is currently experiencing high demand and cannot process your request. Your request exceeds the maximum usage size allowed during peak load.",
+	"no healthy upstream",
+];
+
+describe("capacity error normalization", () => {
+	it.each(CAPACITY_ERRORS)("keeps Azure capacity failures non-retryable: %s", (errorMessage) => {
+		const original = assistantError(errorMessage);
+		expect(isRetryableAssistantError(original)).toBe(false);
+
+		const normalized = normalizeCapacityError(original);
+		expect(normalized).not.toBe(original);
+		expect(normalized.errorMessage).toBe(`capacity error: ${errorMessage}`);
+		expect(isRetryableAssistantError(normalized)).toBe(false);
+		expect(normalizeTransientNetworkError(normalized)).toBe(normalized);
+	});
+
+	it("does not rewrite generic WebSocket errors until CPA forwards the Azure body", () => {
+		const websocket = assistantError("WebSocket error");
+		expect(isRetryableAssistantError(websocket)).toBe(true);
+		expect(normalizeCapacityError(websocket)).toBe(websocket);
+		expect(normalizeTransientNetworkError(websocket)).toBe(websocket);
+	});
 
 	it("only rewrites assistant errors from the registered provider", () => {
 		let handler: ((event: any, ctx: ExtensionContext) => unknown) | undefined;
@@ -64,6 +93,13 @@ describe("transient network error normalization", () => {
 			message: AssistantMessage;
 		};
 		expect(replacement.message.errorMessage).toBe(`network error: ${TRANSIENT_STREAM_ERRORS[0]}`);
+
+		const capacity = assistantError(CAPACITY_ERRORS[0]);
+		const capacityReplacement = handler({ type: "message_end", message: capacity }, {} as ExtensionContext) as {
+			message: AssistantMessage;
+		};
+		expect(capacityReplacement.message.errorMessage).toBe(`capacity error: ${CAPACITY_ERRORS[0]}`);
+		expect(isRetryableAssistantError(capacityReplacement.message)).toBe(false);
 
 		const otherProvider = assistantError(TRANSIENT_STREAM_ERRORS[0], "other");
 		expect(handler({ type: "message_end", message: otherProvider }, {} as ExtensionContext)).toBeUndefined();


### PR DESCRIPTION
## Why

On this host, Pi `auto` transport was patched to WebSocket-only. Azure OpenAI 502s (peak-size / `no healthy upstream`) close the CPA websocket with no error frame, so Pi reports `WebSocket error` and burns the 13-step cliproxyapi retry schedule on the same oversized payload.

## What

- Prefer SSE when the CPA key has no ChatGPT account id (Azure-mapped models on this provider).
- Keep stock SSE fallback when WebSocket fails before the stream starts.
- After a mid-stream WebSocket failure, record SSE fallback so the next outer retry does not hammer WS again.
- Label Azure peak-size and `no healthy upstream` as non-retryable `capacity error:` messages. Generic `WebSocket error` stays retryable until CPA forwards the Azure body.

## Tests

`npm run check` — 99 tests pass.

## Follow-up

CLIProxyAPI should send a Codex `error` / `response.failed` frame before closing the Pi-facing websocket so remaining WS paths surface the Azure message.